### PR TITLE
Updates privacy link

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -60,7 +60,7 @@
           <a class="rvt-footer-base__link" href="https://accessibility.iu.edu/assistance/">Accessibility</a>
         </li>
         <li class="rvt-footer-base__item">
-          <a class="rvt-footer-base__link" href="#">Privacy Notice</a>
+          <a class="rvt-footer-base__link" href="https://policies.iu.edu/policies/lib-01-libraries-privacy/index.html">Privacy Notice</a>
         </li>
         <li class="rvt-footer-base__item">
           <a class="rvt-footer-base__link" href="https://www.iu.edu/copyright/index.html">Copyright</a> © 2024 The Trustees of <a class="rvt-footer-base__link" href="https://www.iu.edu">Indiana University</a>


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/archives_online/issues/99

Updates privacy link. It should direct to https://policies.iu.edu/policies/lib-01-libraries-privacy/index.html

BEFORE: 
![Zight Recording 2025-04-14 at 08 34 36 AM](https://github.com/user-attachments/assets/f9ea1ca0-84f7-4132-937d-2c5a5e0dd8a8)


AFTER: 
![Zight Recording 2025-04-14 at 08 32 40 AM](https://github.com/user-attachments/assets/ada75c9b-5bca-41a5-8a41-b5ac905a6608)
