### PR TITLE
I97 update start over button link

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec_rails
+  - rubocop-factory_bot
+
 Layout/IndentationWidth:
   Width: 2
 
@@ -17,6 +22,7 @@ AllCops:
     - 'lib/tasks/index.rake'
     - 'README.md'
     - 'app/components/blacklight_range_limit/range_form_component.rb'
+    - 'gems/**/*'
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,12 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 group :development, :test do
+  gem 'bixby'
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'rubocop-factory_bot'
+  gem 'rubocop-rake'
+  gem 'rubocop-rspec_rails'
   gem 'solr_wrapper', '>= 0.3'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,14 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bigdecimal (3.1.9)
     bindex (0.8.1)
+    bixby (5.0.0)
+      rubocop (>= 1, < 2)
+      rubocop-ast
+      rubocop-performance
+      rubocop-rails
+      rubocop-rspec
     blacklight (8.3.0)
       globalid
       i18n (>= 1.7.0)
@@ -111,6 +118,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
+    csv (3.3.4)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -154,7 +162,8 @@ GEM
     http-cookie (1.0.7)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httpclient (2.8.3)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -196,10 +205,9 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marc (1.2.0)
+    marc (1.3.0)
+      nokogiri (~> 1.0)
       rexml
-      scrub_rb (>= 1.0.1, < 2)
-      unf
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
     marcel (1.0.4)
@@ -210,6 +218,7 @@ GEM
     minitest (5.25.1)
     msgpack (1.7.2)
     multi_json (1.15.0)
+    mutex_m (0.3.0)
     mysql2 (0.5.6)
     net-http (0.4.1)
       uri
@@ -299,6 +308,23 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
+    rubocop-performance (1.23.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rails (2.29.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (3.4.0)
+      rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -309,13 +335,18 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scrub_rb (1.0.1)
     selenium-webdriver (4.23.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sentry-rails (5.23.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.23.0)
+    sentry-ruby (5.23.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     slop (4.10.1)
     solr_wrapper (4.0.2)
       http
@@ -336,19 +367,22 @@ GEM
     thor (1.3.1)
     tilt (2.4.0)
     timeout (0.4.1)
-    traject (3.8.2)
+    traject (3.8.3)
       concurrent-ruby (>= 0.8.0)
+      csv
       dot-properties (>= 0.1.1)
       hashie (>= 3.1, < 6)
       http (>= 3.0, < 6)
       httpclient (~> 2.5)
       marc (~> 1.0)
       marc-fastxmlwriter (~> 1.0)
+      mutex_m
       nokogiri (~> 1.9)
       slop (~> 4.0)
       yell
-    traject_plus (2.0.0)
+    traject_plus (2.0.1)
       activesupport
+      csv
       deprecation
       jsonpath
       traject (~> 3.0)
@@ -358,7 +392,6 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.2.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     view_component (3.14.0)
@@ -386,6 +419,7 @@ PLATFORMS
 
 DEPENDENCIES
   arclight
+  bixby
   blacklight-locale_picker
   blacklight_range_limit
   bootsnap
@@ -402,8 +436,13 @@ DEPENDENCIES
   redis (~> 4.0)
   rsolr (>= 1.0, < 3)
   rubocop (>= 1.0)
+  rubocop-factory_bot
+  rubocop-rake
+  rubocop-rspec_rails
   sassc-rails (~> 2.1)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   solr_wrapper (>= 0.3)
   sprockets-rails
   stimulus-rails
@@ -412,7 +451,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.2.5p208
+   ruby 3.2.8p263
 
 BUNDLED WITH
    2.4.22

--- a/app/components/blacklight/start_over_button_component_decorator.rb
+++ b/app/components/blacklight/start_over_button_component_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight v8.3.0 - [i97] - Start Over Button should return the user
+# back to the home page instead of performing an empty search.
+
+module Blacklight
+  module StartOverButtonComponentDecorator
+    private
+
+    def start_over_path
+      root_path
+    end
+  end
+end
+
+Blacklight::StartOverButtonComponent.prepend(Blacklight::StartOverButtonComponentDecorator)


### PR DESCRIPTION
## [i97] - Start Over button to match production behavior

69396595e3211b1801c873aba197638b4c0322b2

In production, clicking the "Start Over" button takes the user back to the homepage. Currently, it performs an empty search instead.

This PR overrides the default behavior to restore parity with production.

Issue: https://github.com/notch8/archives_online/issues/97

## BEFORE

![Zight Recording 2025-04-14 at 02 14 35 PM](https://github.com/user-attachments/assets/a8f0ffc1-4fbd-4cc2-9d35-dee93d792283)


## AFTER

![Zight Recording 2025-04-14 at 02 15 15 PM](https://github.com/user-attachments/assets/a9e8f1e2-d841-4035-81ea-05418ecd7f67)


## PROD

![Zight Recording 2025-04-14 at 02 15 40 PM](https://github.com/user-attachments/assets/035f4611-33b4-4e21-af96-9d93381fce44)


## ⚙️ expand rubocop

43c011b87311cd5ef5d21cc6020647ff70cfdb00

Devs were unable to run rubocop.
