### PR TITLE
[i93] - Fix collection facet behavior in "View all" results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -148,7 +148,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'campus_unit_ssim', label: 'Campus', helper_method: :render_campus_facet
     config.add_facet_field 'repository_ssim', label: 'Repository', limit: 10
-    config.add_facet_field 'collection_ssim', label: 'Collection', limit: 10
+    config.add_facet_field 'collection', field: 'collection_ssim', label: 'Collection', limit: 10
     config.add_facet_field 'level_ssim', label: 'Level', limit: 10
     config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false


### PR DESCRIPTION
The "View all" link in grouped search results wasn't properly filtering by collection because the facet field configuration in catalog_controller.rb didn't match [Arclight's](https://github.com/projectblacklight/arclight/blob/main/lib/generators/arclight/templates/catalog_controller.rb#L141) expected format. Updated the collection facet configuration to use the 'collection' key while maintaining the 'collection_ssim' Solr field, which aligns with Arclight's default behavior and matches production.

Issue:
- https://github.com/notch8/archives_online/issues/93

## BEFORE

![Zight Recording 2025-04-14 at 03 06 00 PM](https://github.com/user-attachments/assets/a73e4cef-b63b-4399-871c-0b0dbf94b94b)



## AFTER

![Zight Recording 2025-04-14 at 03 07 41 PM](https://github.com/user-attachments/assets/da33a480-7d6b-492e-ae4e-ae68972463e4)


## PROD

![Zight Recording 2025-04-14 at 03 06 48 PM](https://github.com/user-attachments/assets/20a3307d-e1eb-4013-9e73-7aeef9305250)

