### PR TITLE
[i91] - :bug: Fix Name and Subject facet search behavior

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -154,10 +154,10 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'component_level_isim', show: false
     config.add_facet_field 'date_range_isim', label: 'Year', range: { assumed_boundaries: [0, Time.now.year + 2] }
-    config.add_facet_field 'names_ssim', label: 'Names', limit: 10
+    config.add_facet_field 'names', field: 'names_ssim', limit: 10
     config.add_facet_field 'geogname_ssim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false
-    config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
+    config.add_facet_field 'access_subjects', field: 'access_subjects_ssim', label: 'Subject', limit: 10
     config.add_facet_field 'parent_ssim', show: false
 
     # Have BL send all facet field names to Solr, which has been the default


### PR DESCRIPTION
The Names and Subject links in search results weren't properly filtering. I updated their configuration in the catalog controller, which aligns with Arclight's default behavior and matches production.

Issue:
- #91

## BEFORE

![Zight Recording 2025-04-15 at 08 28 59 AM](https://github.com/user-attachments/assets/06d3a1ca-d4d6-4725-8efb-42c7d1b5c795)



## AFTER

![Zight Recording 2025-04-15 at 08 27 55 AM](https://github.com/user-attachments/assets/a334b42e-57ed-4a44-88b7-954511238e82)
