### PR TITLE
[i104] - swap order of scopecontent and bioghist

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -311,8 +311,8 @@ class CatalogController < ApplicationController
     config.add_summary_field 'prefercite', field: 'prefercite_html_tesm', helper_method: :render_html_tags
 
     # Collection Show Page - Background Section
-    config.add_background_field 'scopecontent', field: 'scopecontent_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'bioghist', field: 'bioghist_html_tesm', helper_method: :render_html_tags
+    config.add_background_field 'scopecontent', field: 'scopecontent_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'acqinfo', field: 'acqinfo_ssim', helper_method: :render_html_tags
     config.add_background_field 'appraisal', field: 'appraisal_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'custodhist', field: 'custodhist_html_tesm', helper_method: :render_html_tags


### PR DESCRIPTION
This swaps the display of scope content and biographical/historical notes for parity with production.

Issue:
- #104

## BEFORE

<img width="508" alt="image" src="https://github.com/user-attachments/assets/04a27f88-f8e1-4602-ab60-b9978f926933" />


## AFTER

<img width="541" alt="image" src="https://github.com/user-attachments/assets/f82e0999-f8f7-434b-a288-97ed33a82f59" />


## PROD

https://archives.iu.edu/catalog/ua044

<img width="308" alt="image" src="https://github.com/user-attachments/assets/f8b11947-e7a7-4eda-95d8-f8e770fe96c8" />
