### PR TITLE
🎁 Exposing Collection ID Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # archives_online
 Archives Online, an application supporting discovery of archival materials, based on ArcLight
 
-* Arclight *
+*Arclight*
 A Rails engine supporting discovery of archival materials, based on Blacklight
 
 
@@ -84,7 +84,7 @@ bundle exec rake
 
 ## Locally without Docker
 
-Please note that this is unused by SoftServ
+Please note that this is unused by Notch8
 
 ### Compatibility
 
@@ -106,6 +106,8 @@ archives_online relies on helm charts for deployment to kubernetes containers. W
 
 ### EAD Files
 
+Run this command in the container to create works
+
 ```
 DIR=data rake arclight:index_dir
 ```
@@ -113,11 +115,14 @@ DIR=data rake arclight:index_dir
 ## Setup in k8 env
 
 ### Creating solr collections in k8 env with zookeeper
+
+```
 curl -X POST "http://admin:$SOLR_ADMIN_PASSWORD@solr.staging-solr:8983/solr/admin/collections?action=CREATE&name=archives-online&numShards=1&collection.configName=archives-online"
+```
 
 ## Debugging
 
-To use a debugger, create a docker-compose.override.yml file with the following contents
+To use a debugger, create a `docker-compose.override.yml` file with the following contents
 
 ```
 services:
@@ -138,3 +143,58 @@ Manually start the application and go into docker's bash:
 To use the debugger command, you may need to add the following to the file:
 
 `require 'debug'; debugger`
+
+### Overriding Arclight Views
+
+The Arclight gem uses [Rails ViewComponent](https://viewcomponent.org/) to build markup. ViewComponents pair a Ruby component class with a corresponding markup file.
+
+For example:
+
+```plaintext
+arclight
+  └──app
+    └── components
+      └── arclight
+        ├── bookmark_component.html.erb
+        └── bookmark_component.rb
+```
+
+
+It is often necessary to override views in the Arclight gem to modify the look or behavior of the archives_online application. To override a view, create files of the same name in `archives_online/app/components/ngao/arclight`.
+
+```plaintext
+archives_online
+  └──app
+    └── components
+        └── ngao
+          └── arclight
+            ├── bookmark_component.html.erb
+            └── bookmark_component.rb
+```
+
+The Ruby class will follow the pattern:
+
+```ruby
+module Ngao
+  module Arclight
+    class BookmarkComponent < ::Arclight::BookmarkComponent
+    end
+  end
+end
+```
+
+Methods can be added to modify behavior as needed. If no behavior change is needed the class with inherit functionality from the Arclight gem.
+
+View files will need to be copied in their entirety then modified as need.
+
+Call the Ruby file in the `catalog_controller.rb` file to instantiate the class.
+
+```ruby
+config.show.bookmark_component = Ngao::Arclight::BookmarkComponent
+```
+
+Please note the Arclight version and what is being added or removed in the override in the file. This allows for clear communication and to more easily manage Arclight gem updates. 
+
+```
+# OVERRIDE Arclight v1.4.0 to <your change here>
+```

--- a/app/components/ngao/arclight/collection_context_component.html.erb
+++ b/app/components/ngao/arclight/collection_context_component.html.erb
@@ -1,0 +1,20 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to add the collection unitid
+  @see: Ngao::Arclight::CollectionContextComponent
+%>
+
+<div class="al-show-actions-box mb-3">
+  <div class="al-actions-box-container">
+    <button type="button" class="btn-close d-lg-none float-end mt-1 me-1" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>
+    <div class="d-flex flex-row justify-content-between">
+      <h2>Collection</h2>
+      <div><%= t('.collection_id') %>: <%= collection['unitid_ssm']&.first %></div>
+    </div>
+    <h3><%= title %></h3>
+
+    <div class="al-collection-context-actions d-flex flex-wrap gap-1">
+      <%= document_download %>
+      <%= collection_info %>
+    </div>
+  </div>
+</div>

--- a/app/components/ngao/arclight/collection_context_component.rb
+++ b/app/components/ngao/arclight/collection_context_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0 to add collection_id to the collection context
+
+module Ngao
+  module Arclight
+    class CollectionContextComponent < ::Arclight::CollectionContextComponent
+      def collection_info
+        render Ngao::Arclight::CollectionInfoComponent.new(collection: collection)
+      end
+    end
+  end
+end

--- a/app/components/ngao/arclight/collection_info_component.html.erb
+++ b/app/components/ngao/arclight/collection_info_component.html.erb
@@ -1,0 +1,29 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to remove collection_id from the dropdown
+  @see: Ngao::Arclight::CollectionInfoComponent
+%>
+
+<div class="al-show-actions-box-info">
+  <div class="dropdown">
+    <button class="dropdown-toggle btn btn-secondary btn-sm" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <%= info_icon %> <%= t('.more_info') %>
+    </button>
+    <div class="dropdown-menu shadow-lg p-2" style="min-width: 300px">
+      <table style="width: 100%">
+      <%# OVERRIDE - collection_id removed %>
+        <tr>
+          <th scope="row"><%= t('.total_components') %></th>
+          <td><%= total_component_count %></td>
+        </tr>
+        <tr>
+          <th scope="row"><%= t('.online_items') %></th>
+          <td><%= tag.span blacklight_icon(:online), class: 'al-online-content-icon' %><%= online_item_count %></td>
+        </tr>
+        <tr>
+          <th scope="row"><%= t('.last_indexed') %></th>
+          <td><%= last_indexed.strftime('%F') %></td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/components/ngao/arclight/collection_info_component.rb
+++ b/app/components/ngao/arclight/collection_info_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0 to remove collection_id from the dropdown
+
+module Ngao
+  module Arclight
+    class CollectionInfoComponent < ::Arclight::CollectionInfoComponent
+    end
+  end
+end

--- a/app/components/ngao/arclight/sidebar_component.rb
+++ b/app/components/ngao/arclight/sidebar_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0 to add collection_id to the collection context
+
+module Ngao
+  module Arclight
+    class SidebarComponent < ::Arclight::SidebarComponent
+      def collection_context
+        render Ngao::Arclight::CollectionContextComponent.new(presenter: document_presenter(document),
+                                                              download_component: ::Arclight::DocumentDownloadComponent)
+      end
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,7 +81,8 @@ class CatalogController < ApplicationController
     # solr field configuration for document/show views
     # config.show.title_field = 'title_display'
     config.show.document_component = Ngao::Arclight::DocumentComponent
-    config.show.sidebar_component = Arclight::SidebarComponent
+    config.show.sidebar_component = Ngao::Arclight::SidebarComponent
+    config.show.collection_info_component = Ngao::Arclight::CollectionInfoComponent
     config.show.breadcrumb_component = Ngao::Arclight::BreadcrumbsHierarchyComponent
     config.show.embed_component = UniversalViewer
     config.show.access_component = Arclight::AccessComponent

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -76,3 +76,7 @@ en:
           place: Place
           subject: Subject
           access: Access
+  ngao:
+    arclight:
+      collection_context_component:
+        collection_id: Collection ID


### PR DESCRIPTION
# Story: [i101] Exposing the Collection ID Number

Ref:
- https://github.com/notch8/archives_online/issues/101

## Expected Behavior Before Changes

The Collection ID number was in the `More Info` dropdown menu. 

## Expected Behavior After Changes

The Collection ID number is in the top right corner of the Collection section.

## Screenshots / Video

<details>
<summary>Before</summary>

![Screenshot 2025-04-15 at 12 40 54 PM](https://github.com/user-attachments/assets/87487f72-9179-4b90-beb7-4cac27d8d833)

</details>

<details>
<summary>After</summary>

![Screenshot 2025-04-15 at 11 38 28 AM](https://github.com/user-attachments/assets/dc45156f-c0b8-4eff-a88c-b383004eceb9)

</details>

## Notes

Added notes to the README on the process for overriding Arclight views.