### PR TITLE
[i88]- Allow search result breadcrumb items to expand vertically

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -57,3 +57,26 @@ body {
 .collapsing {
   transition: height 0.25s ease;
 }
+
+// Force wrapping and line height for long breadcrumb links in search results
+.al-document-listings {
+  dl.document-metadata {
+    .breadcrumb-links {
+      ol.breadcrumb {
+        li.breadcrumb-item {
+          height: auto !important;
+          vertical-align: top !important;
+
+          a {
+            display: inline !important;
+            white-space: normal !important;
+            word-break: break-word !important;
+            overflow-wrap: break-word !important;
+            line-height: 1.4 !important;
+            margin-bottom: 0 !important;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Breadcrumbs overlapped when a link's text was too long

Issue:
- #88

## BEFORE

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/d0db57f5-c6ca-435c-9a2c-95613aa76b85" />


## AFTER


<img width="1141" alt="image" src="https://github.com/user-attachments/assets/60406339-ffed-4760-bfb8-eaa86eb311c4" />
