### PR TITLE
[i108] - removes dupe scope content in catalog search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -186,9 +186,6 @@ class CatalogController < ApplicationController
       last_word_connector: '<br/>'
     }, compact: true, component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'creator', accessor: true, component: Arclight::IndexMetadataFieldComponent
-    config.add_index_field 'abstract_or_scope', accessor: true, truncate: true, repository_context: true,
-                                                helper_method: :render_html_tags,
-                                                component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'breadcrumbs', accessor: :itself,
                                           component: Ngao::Arclight::SearchResultBreadcrumbsComponent,
                                           compact: { count: 2 }


### PR DESCRIPTION
Removes the 'abstract_or_scope' index field from catalog controller to fix duplication issue: A user would see the same data twice when performing a catalog search.

Issue:
- #108

## BEFORE

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/17f5a43e-eaad-4a72-bc9b-e02338304ef5" />


## AFTER

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/9772f4dc-f496-4182-9ea9-0473d98b7ff8" />
