### PR TITLE
🎁 Add html render support for unit titles

### DIFF
--- a/app/components/ngao/arclight/document_component.html.erb
+++ b/app/components/ngao/arclight/document_component.html.erb
@@ -1,6 +1,8 @@
 <%#
   OVERRIDE Arclight v1.4.0 to remove bookmarks
   @see: Ngao::Arclight::DocumentComponent
+
+  Also to, render normlized_html_title
 %>
 
 <div class='d-md-flex justify-content-between al-show'>
@@ -13,7 +15,7 @@
 
 <div class="title-container">
   <%= content_tag :h1 do %>
-    <%= document.normalized_title %>
+    <%= helpers.render_html_tags({ value: document.normalized_title_html }) || document.normalized_title %>
   <% end %>
   <%= render 'arclight/requests', document: document %>
   <%#= render Arclight::BookmarkComponent.new document: document, action: bookmark_config %>

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,4 +25,8 @@ class SolrDocument
   def containers
     fetch('containers_ssim', [])
   end
+
+  def normalized_title_html
+    self['normalized_title_html_ssm']&.first
+  end
 end

--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -107,6 +107,7 @@ end
 to_field 'title_filing_ssi', extract_xpath('./did/unittitle'), first_only
 to_field 'title_ssm', extract_xpath('./did/unittitle')
 to_field 'title_tesim', extract_xpath('./did/unittitle')
+to_field 'title_html_tesm', extract_xpath('./did/unittitle', to_text: false)
 
 to_field 'unitdate_bulk_ssim', extract_xpath('./did/unitdate[@type="bulk"]')
 to_field 'unitdate_inclusive_ssm', extract_xpath('./did/unitdate[@type="inclusive"]')
@@ -122,6 +123,12 @@ end
 
 to_field 'normalized_title_ssm' do |_record, accumulator, context|
   title = context.output_hash['title_ssm']&.first
+  date = context.output_hash['normalized_date_ssm']&.first
+  accumulator << settings['title_normalizer'].constantize.new(title, date).to_s
+end
+
+to_field 'normalized_title_html_ssm' do |_record, accumulator, context|
+  title = context.output_hash['title_html_tesm']&.first&.to_xml
   date = context.output_hash['normalized_date_ssm']&.first
   accumulator << settings['title_normalizer'].constantize.new(title, date).to_s
 end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -90,6 +90,7 @@ end
 
 to_field 'title_filing_ssi', extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
 to_field 'title_ssm', extract_xpath('/ead/archdesc/did/unittitle')
+to_field 'title_html_tesm', extract_xpath('/ead/archdesc/did/unittitle', to_text: false)
 to_field 'title_tesim', extract_xpath('/ead/archdesc/did/unittitle')
 to_field 'ead_ssi', extract_xpath('/ead/eadheader/eadid')
 
@@ -125,6 +126,12 @@ end
 
 to_field 'normalized_title_ssm' do |_record, accumulator, context|
   title = context.output_hash['title_ssm']&.first
+  date = context.output_hash['normalized_date_ssm']&.first
+  accumulator << settings['title_normalizer'].constantize.new(title, date).to_s
+end
+
+to_field 'normalized_title_html_ssm' do |_record, accumulator, context|
+  title = context.output_hash['title_html_tesm']&.first&.to_xml
   date = context.output_hash['normalized_date_ssm']&.first
   accumulator << settings['title_normalizer'].constantize.new(title, date).to_s
 end


### PR DESCRIPTION
This commit will add HTML rendering for titles on the components so that if the EAD says something like <title render=\"italic\">The Hill</title> then it will be converted to <em>The Hill</em> on the show page.

Ref:
- https://github.com/notch8/archives_online/issues/102

<img width="832" alt="image" src="https://github.com/user-attachments/assets/deec6406-1f1e-40ca-b846-324e577ee4b9" />
