### PR TITLE
🎁 [i133] - linked Creator performs facet search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -151,7 +151,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'repository_ssim', label: 'Repository', limit: 10
     config.add_facet_field 'collection', field: 'collection_ssim', label: 'Collection', limit: 10
     config.add_facet_field 'level_ssim', label: 'Level', limit: 10
-    config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
+    config.add_facet_field 'creators', field: 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'component_level_isim', show: false
     config.add_facet_field 'date_range_isim', label: 'Year', range: { assumed_boundaries: [0, Time.now.year + 2] }


### PR DESCRIPTION
Issue:
- #133

related:
- #91

Clicking on a linkted term (creator) should perform a faceted search.

## BEFORE

clicking on creator performed an empty search => 

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/2266205c-347f-4c09-9a9f-916f652b1572" />


## AFTER

![Zight Recording 2025-04-16 at 02 11 39 PM](https://github.com/user-attachments/assets/43ba72b4-b0ba-4202-bb58-ae0e68af3c14)
