### PR TITLE
🎁 Formatting applied to all Extents display

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -216,20 +216,32 @@ to_field 'physdesc_tesim', extract_xpath('/ead/archdesc/did/physdesc', to_text: 
   end
 end
 
-to_field 'extent_ssm' do |record, accumulator|
-  physdescs = record.xpath('/ead/archdesc/did/physdesc')
-  extents_per_physdesc = physdescs.map do |physdesc|
-    extents = physdesc.xpath('./extent').map { |e| e.text.strip }
-    # Join extents within the same physdesc with an empty string
-    extents.join(' ') unless extents.empty?
+to_field 'extent_ssm', extract_xpath('/ead/archdesc/did/physdesc', to_text: false) do |_record, accumulator|
+  accumulator.map! do |element|
+    extent_array = []
+    %w[extent].map do |selector|
+      extent = element.xpath(".//#{selector}").map(&:text)
+      first = extent.shift unless extent.empty?
+      others = "(#{extent.join(' ')})" unless extent.empty?
+      extent_array << first unless first.nil?
+      extent_array << others unless others.nil?
+    end.flatten
+    extent_array.join(' ') unless extent_array.empty?
   end
-
-  # Add each physdesc separately to the accumulator
-  accumulator.concat(extents_per_physdesc)
 end
 
-to_field 'extent_tesim' do |_record, accumulator, context|
-  accumulator.concat context.output_hash['extent_ssm'] || []
+to_field 'extent_tesim', extract_xpath('/ead/archdesc/did/physdesc', to_text: false) do |_record, accumulator|
+  accumulator.map! do |element|
+    extent_array = []
+    %w[extent].map do |selector|
+      extent = element.xpath(".//#{selector}").map(&:text)
+      first = extent.shift unless extent.empty?
+      others = "(#{extent.join(' ')})" unless extent.empty?
+      extent_array << first unless first.nil?
+      extent_array << others unless others.nil?
+    end.flatten
+    extent_array.join(' ') unless extent_array.empty?
+  end
 end
 
 to_field 'physfacet_tesim', extract_xpath('/ead/archdesc/did/physdesc/physfacet')


### PR DESCRIPTION
# Story: [i107] Fixing concatenated extents display

Ref:
- https://github.com/notch8/archives_online/pull/new/i107-extents-display

## Notes

Modifying `extent_ssm` and `extent_tesim` to format the XML tags nested within physical description to differentiate between the space occupied and the description of the physical containers.

Previously: `15 cubic feet Seven boxes, 24 x 15 x 10 1/4"; 26 folder boxes, 11.5 x 6.5 x 5.5"; bulk of documents`

With this commit: `15 cubic feet (Seven boxes, 24 x 15 x 10 1/4"; 26 folder boxes, 11.5 x 6.5 x 5.5"; bulk of documents)`

## Screenshots / Video

<details>
<summary>Before</summary>

![Screenshot 2025-04-16 at 2 16 44 PM](https://github.com/user-attachments/assets/aae6cee8-a9f1-4d8d-b18b-cd97d58f3f56)

</details>

<details>
<summary>After</summary>

![Screenshot 2025-04-16 at 2 14 57 PM](https://github.com/user-attachments/assets/22ea6437-4568-4998-b71b-c8240f2e88ff)

</details>