### PR TITLE
I111 enable printable view functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ yarn-debug.log*
 /storage/*
 !/storage/.keep
 /public/uploads
+
+/public/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,6 @@ RUN /sbin/setuser app bash -l -c " \
     cd /home/app/webapp && \
     yarn install && \
     NODE_ENV=production DB_ADAPTER=nulldb bundle exec rake assets:precompile"
+RUN cp ./app/assets/stylesheets/print.scss ./public/assets/print.scss
 
 CMD ["/sbin/my_init"]

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -22,6 +22,11 @@ $component-indent: 2rem;  // Modify this value to change indentation between lev
 body.ead-print {
   font-family: GeorgiaPro, Georgia, "Times New Roman", Times, serif;
   margin: auto;
+
+  font-size: 12pt;
+  padding-top: 5rem;
+  width: 70rem;
+  max-width: 95%;
 }
 
 .no-bullets {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,317 @@
+$component-indent: 2rem;  // Modify this value to change indentation between levels
+
+@media screen {
+  body.ead-print {
+    font-size: 12pt;
+    padding-top: 5rem;
+    width: 70rem;
+    max-width: 95%;
+  }
+}
+
+@media print {
+  html {
+    width: 100%;
+  }
+
+  body.ead-print {
+    font-size: 10pt;
+  }
+}
+
+body.ead-print {
+  font-family: GeorgiaPro, Georgia, "Times New Roman", Times, serif;
+  margin: auto;
+}
+
+.no-bullets {
+  list-style-type: none;
+}
+
+div.title-block {
+  text-align: center;
+  padding-bottom: 1rem;
+  border-bottom: 2.5pt solid;
+
+  h1 {
+    font-size: 175%;
+  }
+
+  p {
+    font-size: 125%;
+  }
+}
+
+div.did {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 2.5pt solid;
+}
+
+table {
+  table-layout: fixed; // fix to prevent firefox from trying to distribute columns evenly
+  width: 95%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1em;
+  font-size: 100%; // required to override some user agent stylesheets
+
+  thead {
+    vertical-align: top; // required to override some user agent stylesheets
+    font-weight: bold;
+  }
+
+  tbody {
+    vertical-align: top; // required to override some user agent stylesheets
+  }
+
+  td {
+    min-width: 15%;
+  }
+}
+
+table.overview {
+  width: 100%;
+  td {
+    padding-top: .25rem;
+  }
+
+  td.did-label {
+    font-weight: bold;
+    vertical-align: text-top;
+    width: 8.5rem;
+  }
+
+  td.did-value {
+    font-weight: normal;
+  }
+}
+
+table.chronlist {
+  td.date {
+    width: 8rem;
+  }
+  h4 {
+    margin-block-end: 0.25rem;
+  }
+}
+
+div.archdesc-section {
+  border-bottom: 1.5pt solid;
+
+  h3 {
+    margin-block-end: 0.5rem;
+  }
+
+  p {
+    margin-block-start: 0.25rem;
+  }
+
+  ul.subject-headings {
+    list-style-type: none;
+    margin: 0;
+    padding-inline-start: 0; // required to override some user agent stylesheets
+
+    h5 {
+      font-size: 100%;
+      margin-block-start: 0;
+      margin-block-end: 0;
+    }
+
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+    }
+  }
+
+  li.subj-label {
+    margin-bottom: 0.75rem;
+    display: flex;
+
+    ul {
+      margin-top: 0;
+    }
+
+    .label, h5 {
+      width: 9rem;
+      text-align: right;
+      margin-right: 1rem;
+    }
+  }
+}
+
+div.archdesc-section.restrict {
+  h4 {
+    display: inline;
+    margin-right: .5rem;
+    margin-top: 0;
+    margin-bottom: 0;
+    float: left;
+  }
+}
+
+div.archdesc-section.admininfo {
+  .subhead-1 {
+    font-weight: bold;
+    display: inline;
+  }
+}
+ul.bibliography {
+  margin-block-start: 0.5rem;
+}
+
+// Banding
+.component:nth-of-type(odd) {
+  background-color: #edebeb;
+  margin-left: -4pt;
+  padding-left: 4pt;
+}
+
+// Every component level has this class plus a separate class with the component name
+// components are nested inside one another, but take up the full printable with
+div.component {
+  display: flex;
+
+  p, ol, ul {
+    margin-block-start: 0.25rem;
+    margin-block-end: 0.25rem;
+  }
+
+  .label {
+    //font-family: GeorgiaProBold, Georgia, "Times New Roman", Times, serif;
+    //font-weight: bold;
+
+    text-transform: uppercase;
+    color: #4A3C31; //#7D6F64;
+  }
+
+  // The box-folder class contains any identifying info for the physical container
+  div.box-folder {
+    margin-bottom: 6pt;
+    padding-top: 5.5pt; // should match height of the rule above .container-info to keep things aligned
+    font-family: BentonSansCondBold, "Arial Narrow", "Helvetica Neue Condensed Bold", sans-serif;
+    font-weight: bold;
+    vertical-align: top;
+    width: 6rem; // fixed-width to accommodate the largest "Box X, Folder Y" string expected
+  }
+
+  // The component-info contains descriptive text about the container
+  div.component-info{
+    border-top: 1.25pt solid dimgrey;
+    padding-top: 4pt;
+    padding-left: 4pt;
+    margin-bottom: 6pt;
+    width: 100%;
+
+    h4, h5 {
+      display: inline;
+      color: #4A3C31; //#7D6F64;
+      text-transform: uppercase;
+      margin-right: .5rem;
+      margin-top: 4pt;
+      margin-bottom: 0;
+    }
+
+    h5 {
+      font-size: initial;
+    }
+  }
+
+  .unittitle {
+    display: inline;
+    font-family: GeorgiaProBold, Georgia, "Times New Roman", Times, serif;
+    margin-bottom: 6pt;
+  }
+}
+
+.unittitle.series, .unittitle.subseries {
+  font-size: 115%;
+  font-weight: bold;
+}
+
+// Container level-specific formatting, primarily indentation
+
+.c01 div.component-info,
+.c   div.component-info {
+  margin-left: 0;  // Using 0 margin-left to make the rest of the math easier, set the margin-right on .box-folder instead
+}
+
+.c02 div.component-info {
+  margin-left: $component-indent;
+}
+
+.c03 div.component-info {
+  margin-left: $component-indent * 2;
+}
+
+.c04 div.component-info {
+  margin-left: $component-indent * 3;
+}
+
+.c05 div.component-info {
+  margin-left: $component-indent * 4;
+}
+
+.c06 div.component-info {
+  margin-left: $component-indent * 5;
+}
+
+.c07 div.component-info {
+  margin-left: $component-indent * 6;
+}
+
+.c08 div.component-info {
+  margin-left: $component-indent * 7;
+}
+
+.c09 div.component-info {
+  margin-left: $component-indent * 8;
+}
+
+.c10 div.component-info {
+  margin-left: $component-indent * 9;
+}
+.c11 div.component-info {
+  margin-left: $component-indent * 10;
+}
+
+.c12 div.component-info {
+  margin-left: $component-indent * 11;
+}
+
+
+// Colorful debugging, remove or comment out for production
+//div.component.c01 {
+//  margin: 2px;
+//  border: 1px solid red;
+//}
+//
+//div.component.c02 {
+//  margin: 2px;
+//  border: 1px solid darkorange;
+//}
+//
+//div.component.c03 {
+//  margin: 2px;
+//  border: 1px solid gold;
+//}
+//
+//div.component.c04 {
+//  margin: 2px;
+//  border: 1px solid green;
+//}
+//
+//div.component.c05 {
+//  margin: 2px;
+//  border: 1px solid blue;
+//}
+//
+//div.component.c06 {
+//  margin: 2px;
+//  border: 1px solid indigo;
+//}
+//
+//div.component.c07 {
+//  margin: 2px;
+//  border: 1px solid violet;
+//}

--- a/app/components/ngao/arclight/document_download_component.rb
+++ b/app/components/ngao/arclight/document_download_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0 to add the #printable_view_icon method to display the desired icon
+
+module Ngao
+  module Arclight
+    class DocumentDownloadComponent < ::Arclight::DocumentDownloadComponent
+      def printable_view_icon
+        icon = <<~HTML
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
+            <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z"/>
+            <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z"/>
+          </svg>
+        HTML
+        icon.html_safe
+      end
+    end
+  end
+end

--- a/app/components/ngao/arclight/sidebar_component.rb
+++ b/app/components/ngao/arclight/sidebar_component.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 # OVERRIDE Arclight v1.4.0 to add collection_id to the collection context
+#   and to render the `Ngao::Arclight::DocumentDownloadComponent`
 
 module Ngao
   module Arclight
     class SidebarComponent < ::Arclight::SidebarComponent
       def collection_context
-        render Ngao::Arclight::CollectionContextComponent.new(presenter: document_presenter(document),
-                                                              download_component: ::Arclight::DocumentDownloadComponent)
+        render Ngao::Arclight::CollectionContextComponent.new(
+          presenter: document_presenter(document),
+          download_component: Ngao::Arclight::DocumentDownloadComponent
+        )
       end
     end
   end

--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -242,7 +242,7 @@ class EadProcessor
     xslt = Nokogiri::XSLT(File.read('app/templates/template.xslt'))
     doc = Nokogiri::XML(File.read(file))
     # ensure filename matches id
-    filename = doc.xpath('//*[local-name()="eadid"]').first.text || File.basename(file, '.xml')
+    filename = doc.xpath('//*[local-name()="eadid"]').first&.text || File.basename(file, '.xml')
     doc.remove_namespaces!
     File.write("public/html/#{filename}.html", xslt.transform(doc))
   end

--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+class EadProcessor
+  require 'zip'
+
+  # calls all the methods
+  def self.import_eads(args = {})
+    process_files(args)
+  end
+
+  def self.import_updated_eads(args = {})
+    process_updated_files(args)
+  end
+
+  # sets the url
+  def self.client(args = {})
+    args[:url] || ENV['ASPACE_EXPORT_URL'] || 'http://localhost/assets/ead_export/'
+  end
+
+  # Open web address with Nokogiri
+  def self.page(args = {})
+    Nokogiri::HTML(URI.open(client(args)))
+  end
+
+  # open file and call extract
+  def self.process_files(args = {})
+    page(args).css('a').each do |file_link|
+      file_name = file_link.attributes['href'].value
+      link = client(args) + file_name
+      directory = File.basename(file_name, File.extname(file_name))
+      ext = File.extname(file_name)
+      next unless ext == '.zip'
+      next unless should_process_file(args, directory)
+
+      URI.open(link, 'rb') do |file|
+        directory = directory.parameterize.underscore
+        extract_and_index(file, directory)
+      end
+    end
+  end
+
+  def self.process_updated_files(args = {})
+    page(args).css('a').each do |file_link|
+      file_name = file_link.attributes['href'].value
+      file_name.slice! client(args)
+      repository = File.dirname(file_name)
+      file = File.basename(file_name)
+      ext = File.extname(file_name)
+      next unless ext == '.xml'
+
+      args = { ead: file, repository: repository }
+      EadProcessor.index_single_ead(args)
+    end
+  end
+
+  # unzip the file and call index
+  def self.extract_and_index(file, directory)
+    Zip::File.open(file) do |zip_file|
+      zip_file.each do |f|
+        path = "./data/#{directory}"
+        FileUtils.mkdir_p path
+        fpath = File.join(path, f.name)
+        FileUtils.rm_f(fpath)
+        filename = File.basename(fpath)
+        zip_file.extract(f, fpath)
+        add_ead_to_db(filename, directory)
+        add_last_indexed(filename, DateTime.now)
+        EadProcessor.save_ead_for_downloading(fpath)
+        EadProcessor.convert_ead_to_html(fpath)
+        EadProcessor.delay.index_file(fpath, directory)
+      end
+    end
+  end
+
+  # for indexing a single ead file
+  # need to unzip parent and index only the file selected
+  def self.index_single_ead(args = {})
+    repository = args[:repository]
+    file_name = args[:ead]
+    link = client(args) + "#{repository}/#{file_name}"
+    directory = repository.parameterize.underscore
+    path = "./data/#{directory}"
+    FileUtils.mkdir_p(path)
+    puts link
+    download = URI.open(link, 'rb')
+    fpath = File.join(path, file_name)
+    IO.copy_stream(download, fpath)
+    filename = File.basename(fpath)
+    add_last_indexed(filename, DateTime.now)
+    EadProcessor.save_ead_for_downloading(fpath)
+    EadProcessor.convert_ead_to_html(fpath)
+    EadProcessor.delay.index_file(fpath, repository)
+  end
+
+  # for deleting a single ead file
+  def self.delete_single_ead(args = {})
+    filename = args[:ead]
+    ENV['FILE'] = filename
+    system('bundle exec rake ngao:delete_ead', exception: true)
+    # FIXME: In production deployment, the row isn't being destroyed by the rake task
+    #  so try a direct invocation of the remove_ead_from_db method
+    remove_ead_from_db(filename)
+  end
+
+  # extract file
+  def self.extract_file(file, directory)
+    Zip::File.open(file) do |zip_file|
+      zip_file.each do |f|
+        path = "./data/#{directory}"
+        FileUtils.mkdir_p path
+        fpath = File.join(path, f.name)
+        File.delete(fpath) if File.exist?(fpath)
+        zip_file.extract(f, fpath)
+      end
+    end
+  end
+
+  # index a file
+  def self.index_file(filename, repository)
+    ENV['REPOSITORY_ID'] = repository
+    ENV['FILE'] = filename
+    system('bundle exec rake arclight:index', exception: true)
+  end
+
+  # get list of zip files and ead contents to show on admin import page
+  def self.get_repository_names(args = {})
+    repositories = {}
+    page(args).css('a').each do |repository|
+      name = repository.attributes['href'].value
+      link = client(args) + name
+      ext = File.extname(name)
+      key = File.basename(name, File.extname(name))
+      next unless ext == '.zip'
+
+      value = { name: repository.children.text }
+      repositories[key] = value
+      last_updated_at = DateTime.parse(repository.next_sibling.text)
+      update_repository(key, value[:name], last_updated_at)
+      eads = []
+      if ext == '.zip'
+        URI.open(link, 'rb') do |file|
+          eads = get_ead_names(file, key)
+        end
+      end
+      repositories[key][:eads] = eads
+    end
+    repositories
+  end
+
+  # Only updates name & last update date w/ data from aspace
+  def self.update_repository(id, name, last_updated_at)
+    repo = Repository.find_by(repository_id: id)
+    repo.update_attributes(name: name, last_updated_at: last_updated_at)
+  end
+
+  # get list of eads contained in zip file
+  def self.get_ead_names(file, repository)
+    eads = []
+    Zip::File.open(file) do |zip_file|
+      zip_file.each do |entry|
+        if entry.file?
+          eads << entry.name
+          add_ead_to_db(entry.name, repository)
+        end
+      end
+    end
+    eads
+  end
+
+  # get list of eads in solr and postgres but no longer on archive space
+  def self.get_delta_eads(args = {})
+    archive_space_eads = []
+    page(args).css('a').each do |ead|
+      name = ead.attributes['href'].value
+      ext = File.extname(name)
+      name = File.basename(name, File.extname(name))
+      next unless ext == '.xml'
+
+      ead_filename = name + ext
+      archive_space_eads << ead_filename
+    end
+    local_eads = Ead.all.collect.each(&:filename)
+    delta_eads = local_eads - archive_space_eads
+    delta_eads.uniq.sort
+  end
+
+  def self.add_ead_to_db(filename, repository_id)
+    Ead.where(filename: filename).first_or_create do |ead|
+      ead.repository = Repository.find_by(repository_id: repository_id)
+    end
+  end
+
+  def self.remove_ead_from_db(filename)
+    Ead.find_by(filename: filename)&.destroy
+  end
+
+  def self.add_last_indexed(filename, indexed_at)
+    Ead.find_by(filename: filename)&.update_attributes(last_indexed_at: indexed_at)
+  end
+
+  def self.add_last_updated(filename, updated_at)
+    Ead.find_by(filename: filename)&.update_attributes(last_updated_at: updated_at)
+  end
+
+  def self.get_updated_eads(args = {})
+    page(args).css('a').each do |ead|
+      name = ead.attributes['href'].value
+      ext = File.extname(name)
+      name = File.basename(name, File.extname(name))
+      next unless ext == '.xml'
+
+      ead_filename = name + ext
+      ead_last_updated_at = DateTime.parse(ead.next_sibling.text)
+      add_last_updated(ead_filename, ead_last_updated_at)
+    end
+  end
+
+  # copies ead to public directory for downloading
+  def self.save_ead_for_downloading(file)
+    directory = './public/ead'
+    FileUtils.mkdir_p directory
+    fpath = File.join(directory, file)
+    File.delete(fpath) if File.exist?(fpath)
+    FileUtils.cp(file, directory)
+  end
+
+  # converts the saved ead to html and saves in public directory for downloading
+  def self.convert_ead_to_html(file)
+    directory = './public/html'
+    FileUtils.mkdir_p directory
+    filename = File.basename(file, '.xml')
+    xslt = Nokogiri::XSLT(File.read('app/templates/template.xslt'))
+    doc = Nokogiri::XML(File.read(file))
+    doc.remove_namespaces!
+    File.write("public/html/#{filename}.html", xslt.transform(doc))
+  end
+
+  # check if should process file
+  # if args are nil, process all zip files
+  # otherwise, only process the specified file
+  def self.should_process_file(args, name)
+    args[:files].nil? || args[:files].include?(name)
+  end
+end

--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -1,0 +1,1038 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  This EAD stylesheet is reworked from the EAD Cookbook Style 6 and dsc1                 -->
+<!--  an original copy can be found here:                                                    -->
+<!--  https://github.com/saa-ead-roundtable/ead-stylesheets/tree/master/print-friendly-html  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:strip-space elements="*"/>
+	<xsl:output method="html" encoding="UTF-8" doctype-public="-//W3C//DTD HTML 4.0 Transitional//EN"/>
+	<!-- Creates the body of the finding aid.-->
+	<xsl:template match="/ead">
+		<html lang="en">
+			<!-- ****************************************************************** -->
+			<!-- Outputs header information for the HTML document 			-->
+			<!-- ****************************************************************** -->
+			<head>
+				<link rel="stylesheet" href="/assets/print.scss"/>
+				<link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.ico"/>
+				<title>
+					<xsl:apply-templates select="eadheader/filedesc/titlestmt/titleproper"/>
+				</title>
+			</head>
+
+
+			<body class="ead-print">
+
+				<div class="title-block">
+					<xsl:if test="eadheader/filedesc/titlestmt/titleproper">
+						<h1 class="finding-aid-title">
+							<xsl:apply-templates select="eadheader/filedesc/titlestmt/titleproper"/>
+						</h1>
+					</xsl:if>
+
+					<xsl:if test="/ead/eadheader/filedesc/titlestmt/subtitle">
+						<h2 class="finding-aid-subtitle">
+							<xsl:apply-templates select="/ead/eadheader/filedesc/titlestmt/subtitle"/>
+						</h2>
+					</xsl:if>
+
+
+					<p class="finding-aid-author">
+						<xsl:apply-templates select="eadheader/filedesc/titlestmt/author"/>
+					</p>
+				</div>
+
+				<!--To change the order of display, adjust the sequence of
+				the following apply-template statements which invoke the various
+				templates that populate the finding aid. In several cases where
+				multiple elements are displayed together in the output, a call-template
+				statement is used -->
+
+				<div class="archdesc-overview">
+					<xsl:apply-templates select="archdesc/did"/>
+				</div>
+
+				<div class="archdesk-main">
+					<xsl:apply-templates select="archdesc/bioghist"/>
+					<xsl:apply-templates select="archdesc/scopecontent"/>
+					<xsl:apply-templates select="archdesc/arrangement"/>
+					<xsl:apply-templates select="archdesc/otherfindaid"/>
+					<xsl:call-template name="archdesc-restrict"/>
+					<xsl:apply-templates select="archdesc/separatedmaterial"/>
+					<xsl:apply-templates select="archdesc/relatedmaterial"/>
+					<xsl:apply-templates select="archdesc/controlaccess"/>
+					<xsl:apply-templates select="archdesc/odd"/>
+					<xsl:apply-templates select="archdesc/originalsloc"/>
+					<xsl:apply-templates select="archdesc/phystech"/>
+					<xsl:call-template name="archdesc-admininfo"/>
+					<xsl:apply-templates select="archdesc/fileplan | archdesc/*/fileplan"/>
+					<xsl:apply-templates select="archdesc/bibliography"/>
+					<xsl:apply-templates select="archdesc/dsc[count(*)>0]"/>
+					<xsl:apply-templates select="archdesc/index | archdesc/*/index"/>
+				</div>
+			</body>
+		</html>
+	</xsl:template>
+
+
+	<!-- ************************************************************** -->
+	<!-- DID processing:                                                -->
+	<!-- This template creates a table for the top-level did, followed  -->
+	<!-- by each of the did elements.  To change the order of 	        -->
+	<!-- appearance of these elements, change the sequence here.		-->
+	<!-- ************************************************************** -->
+
+	<xsl:template match="archdesc/did">
+		<div class="archdesc did">
+			<table class="overview">
+				<xsl:apply-templates select="origination"/>
+				<xsl:apply-templates select="unittitle"/>
+				<xsl:apply-templates select="unitid"/>
+				<xsl:apply-templates select="unitdate[1]"/>
+				<xsl:apply-templates select="physdesc"/>
+				<xsl:apply-templates select="abstract"/>
+				<xsl:apply-templates select="physloc"/>
+				<xsl:apply-templates select="langmaterial"/>
+				<xsl:apply-templates select="repository"/>
+				<xsl:apply-templates select="materialspec"/>
+				<xsl:apply-templates select="note"/>
+			</table>
+		</div>
+	</xsl:template>
+
+
+	<!-- ******************************************************************	-->
+	<!-- Formats variety of text properties (bold, italic) from @RENDER     -->
+	<!-- Also BLOCKQUOTE handling                                           -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="p">
+		<p>
+			<xsl:apply-templates/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="lb">
+		<br/>
+	</xsl:template>
+
+	<!-- add whitespace between any two adjacent text() elements -->
+	<!-- except for <head> elements which often get a colon added directly after -->
+	<xsl:variable name="space" select="'&#x20;'"/>
+	<xsl:template match="//*[name()!='head']/text()">
+		<xsl:value-of select="."/>
+		<xsl:value-of select="$space"/>
+	</xsl:template>
+
+	<xsl:template match="blockquote">
+		<blockquote>
+			<xsl:apply-templates/>
+		</blockquote>
+	</xsl:template>
+
+	<xsl:template match="blockquote/p">
+		<blockquote>
+			<xsl:apply-templates/>
+		</blockquote>
+	</xsl:template>
+
+	<xsl:template match="emph[@render='bold']">
+		<b>
+			<xsl:apply-templates/>
+		</b>
+	</xsl:template>
+
+	<xsl:template match="emph[@render='italic']">
+		<i>
+			<xsl:apply-templates/>
+		</i>
+	</xsl:template>
+
+	<xsl:template match="emph[@render='underline']">
+		<u>
+			<xsl:apply-templates/>
+		</u>
+	</xsl:template>
+
+	<xsl:template match="emph[@render='sub']">
+		<sub>
+			<xsl:apply-templates/>
+		</sub>
+	</xsl:template>
+
+	<xsl:template match="emph[@render='super']">
+		<super>
+			<xsl:apply-templates/>
+		</super>
+	</xsl:template>
+
+	<xsl:template match="emph[@render='bolditalic']">
+		<b>
+			<i>
+				<xsl:apply-templates/>
+			</i>
+		</b>
+	</xsl:template>
+
+	<xsl:template match="title">
+		<i>
+			<xsl:apply-templates/>
+		</i>
+	</xsl:template>
+
+	<!-- Adds parens around extent elements except for the first entry in archdesc/did -->
+	<xsl:template match="extent | physfacet">
+		<xsl:choose>
+			<xsl:when test="ancestor::did and position() = 1">
+				<xsl:apply-templates/>
+			</xsl:when>
+			<xsl:otherwise>
+				(<xsl:apply-templates/>)
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- LIST                                                               -->
+	<!-- Formats a list anywhere except in ARRANGEMENT or REVISIONDESC.     -->
+	<!-- Two values for attribute TYPE are implemented: "simple" gives      -->
+	<!-- an indented list with no marker, "marked" gives an indented list   -->
+	<!-- with each item bulleted, "ordered" gives a numbered list.          -->
+	<!-- ****************************************************************** -->
+
+
+	<xsl:template match="list[@type='ordered']">
+		<xsl:if test="./item">
+			<ol>
+				<xsl:apply-templates/>
+			</ol>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="list[@type='simple'] | list[@type='deflist']">
+		<xsl:if test="./defitem">
+			<ol class="no-bullets">
+				<xsl:apply-templates/>
+			</ol>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="list">
+		<ul>
+			<xsl:apply-templates/>
+		</ul>
+	</xsl:template>
+
+	<xsl:template match="list/item | defitem">
+		<li>
+			<xsl:apply-templates/>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="defitem/label">
+		<xsl:if test="not(text()=' ' or text()='' or not(text()))">
+			<b>
+				<xsl:apply-templates/>:
+				<xsl:value-of select="$space"/>
+			</b>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="bibref">
+		<li class="bibliography">
+			<xsl:apply-templates/>
+		</li>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- TABLE                                                              -->
+	<!-- Implements a very basic crosswalk of EAD <table> to HTML <table>   -->
+	<!-- as of 2022/06/28, IU has only one collection that uses <table>,    -->
+	<!-- see InU-Ar-VAA1616                                                 -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="table">
+		<table>
+			<xsl:apply-templates/>
+		</table>
+	</xsl:template>
+
+	<xsl:template match="thead">
+		<thead>
+			<xsl:apply-templates/>
+		</thead>
+	</xsl:template>
+
+	<xsl:template match="tbody">
+		<tbody>
+			<xsl:apply-templates/>
+		</tbody>
+	</xsl:template>
+
+	<xsl:template match="thead/row | tbody|row">
+		<tr>
+			<xsl:apply-templates/>
+		</tr>
+	</xsl:template>
+
+	<xsl:template match="entry">
+		<td>
+			<xsl:apply-templates/>
+		</td>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- CHRONLIST                                                          -->
+	<!-- Formats a chronology list with items                               -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="chronlist">
+		<table class="chronlist">
+			<tbody>
+				<xsl:apply-templates/>
+			</tbody>
+		</table>
+	</xsl:template>
+
+	<xsl:template match="chronlist/head">
+		<tr>
+			<td colspan="2">
+				<h4>
+					<xsl:apply-templates/>
+				</h4>
+			</td>
+		</tr>
+	</xsl:template>
+
+	<xsl:template match="chronlist/listhead">
+		<tr>
+			<td class="date">
+				<b>
+					<xsl:apply-templates select="head01"/>
+				</b>
+			</td>
+			<td class="event">
+				<b>
+					<xsl:apply-templates select="head02"/>
+				</b>
+			</td>
+		</tr>
+	</xsl:template>
+
+	<xsl:template match="chronitem">
+		<tr>
+			<td class="date">
+				<xsl:apply-templates select="date"/>
+			</td>
+			<td class="event">
+				<xsl:apply-templates select="event | eventgrp"/>
+			</td>
+		</tr>
+	</xsl:template>
+
+	<xsl:template match="chronitem/eventgrp">
+		<xsl:for-each select="*">
+			<xsl:apply-templates/>
+			<br/>
+		</xsl:for-each>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- TITLEPROPER and SUBTITLE are output                                -->
+	<!-- ****************************************************************** -->
+
+	<!-- suppress <num> nodes from titles -->
+	<xsl:template match="eadheader/filedesc/titlestmt/titleproper">
+		<xsl:apply-templates select="node()[name() != 'num']"/>
+	</xsl:template>
+
+	<!-- suppress <titleproper type='filing'> elements -->
+	<xsl:template match="titleproper[@type='filing']"/>
+
+	<xsl:template match="eadheader/filedesc/titlestmt/author">
+		<xsl:if test="not(contains(text(), 'Finding'))">
+			Finding aid created by
+		</xsl:if>
+		<xsl:apply-templates/>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- COLLECTION INFO:                                                   -->
+	<!-- This handles origination, physdesc, abstract, unitid,              -->
+	<!-- physloc and materialspec elements of archdesc/did which share a    -->
+	<!-- common appearance.  Labels are also generated; to change the label -->
+	<!-- generated for these sections, modify the text below.               -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="archdesc/did/origination
+	| archdesc/did/unittitle
+	| archdesc/did/unitdate
+	| archdesc/did/physdesc
+	| archdesc/did/unitid
+	| archdesc/did/physloc
+	| archdesc/did/abstract
+	| archdesc/did/langmaterial
+	| archdesc/did/materialspec">
+
+		<!-- ****************************************************************** -->
+		<!-- Tests for @LABEL.  If @LABEL is present it is used, otherwise      -->
+		<!-- a label is supplied (to alter supplied text, make change below).   -->
+		<!-- ****************************************************************** -->
+
+		<tr>
+			<td class="did-label">
+				<xsl:choose>
+					<!-- Use @label if it exists -->
+					<xsl:when test="@label">
+						<xsl:value-of select="@label"/>
+						<xsl:text>:</xsl:text>
+					</xsl:when>
+
+					<!--Otherwise, use default label based on the node type  -->
+					<xsl:when test="self::unittitle">
+						<xsl:text>Title:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::repository">
+						<xsl:text>Repository:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::origination">
+						<xsl:text>Creator:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::physdesc">
+						<xsl:text>Quantity:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::physloc">
+						<xsl:text>Location:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::unitid">
+						<xsl:text>Collection No.:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::unitdate">
+						<xsl:text>Dates:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::abstract">
+						<xsl:text>Abstract:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::langmaterial">
+						<xsl:text>Language:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::materialspec">
+						<xsl:text>Technical:</xsl:text>
+					</xsl:when>
+
+					<!-- Include an easily searchable fail-over label in case we missed any node types -->
+					<xsl:otherwise>
+						<xsl:text>ID Section:</xsl:text>
+					</xsl:otherwise>
+				</xsl:choose>
+			</td>
+			<td class="did-value">
+				<xsl:apply-templates/>
+			</td>
+		</tr>
+	</xsl:template>
+
+	<!-- ****************************************************************** -->
+	<!-- REPOSITORY                                                         -->
+	<!-- Provides special handling to pull in publisher address from header -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="archdesc/did/repository">
+		<tr>
+			<td class="did-label">
+				<xsl:choose>
+					<!-- Use @label if it exists -->
+					<xsl:when test="@label">
+						<xsl:value-of select="@label"/>
+						<xsl:text>: </xsl:text>
+					</xsl:when>
+					<!--Otherwise, use default label based on the node type  -->
+					<xsl:otherwise>
+						<xsl:text>Repository:</xsl:text>
+					</xsl:otherwise>
+				</xsl:choose>
+			</td>
+			<td class="did-value">
+				<xsl:apply-templates select="@* | node()"/>
+				<br/>
+				<xsl:apply-templates select="/ead/eadheader/filedesc/publicationstmt/address"/>
+			</td>
+		</tr>
+	</xsl:template>
+
+	<xsl:template match="addressline">
+		<xsl:apply-templates/>
+		<br/>
+	</xsl:template>
+
+	<xsl:template match="addressline/extptr" xmlns:xlink="http://www.w3.org/1999/xlink" >
+		<xsl:choose>
+			<xsl:when test="text()">
+				<xsl:apply-templates/>
+			</xsl:when>
+			<xsl:when test="@title | @xlink:title">
+				<xsl:value-of select="@title | @xlink:title"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="@href | @xlink:href"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- UNITDATE                                                           -->
+	<!-- Concatenate all <unitdate> sibling nodes & display @type           -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="unitdate/child::text()">
+		<xsl:for-each select="parent::node()/../unitdate">
+			<!-- display type if there are additional unitdate nodes -->
+			<xsl:if test="position() != 1 and @type!='inclusive'">
+				<xsl:value-of select="@type"/>
+				<xsl:value-of select="$space"/>
+			</xsl:if>
+
+			<!-- display the unitdate -->
+			<xsl:value-of select="."/>
+
+			<!-- separate multiple entries with a comma -->
+			<xsl:if test="position() != last()">
+				<xsl:text>,</xsl:text>
+				<xsl:value-of select="$space"/>
+			</xsl:if>
+		</xsl:for-each>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- ARCHDESC Processing                                                -->
+	<!-- Formats the top-level bioghist, scopecontent, phystech, odd, and   -->
+	<!-- arrangement elements and creates a link back to the top of the     -->
+	<!-- page after the display of the element.  Each HEAD element is also  -->
+	<!-- given a generated ID so it can be linked to from the TOC.          -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="archdesc/bioghist |
+		archdesc/scopecontent |
+		archdesc/phystech |
+		archdesc/odd   |
+		archdesc/arrangement |
+		archdesc/separatedmaterial |
+		archdesc/relatedmaterial |
+		archdesc/controlaccess |
+		archdesc/otherfindaid |
+		archdesc/originalsloc |
+		archdesc/fileplan |
+		archdesc/dsc |
+		archdesc/index">
+		<div>
+			<xsl:attribute name="class">archdesc-section
+				<xsl:value-of select="name()"/>
+			</xsl:attribute>
+			<xsl:apply-templates/>
+		</div>
+	</xsl:template>
+
+	<xsl:template match="archdesc/bibliography">
+		<div>
+			<xsl:attribute name="class">archdesc-section
+				<xsl:value-of select="name()"/>
+			</xsl:attribute>
+			<xsl:apply-templates select="head"/>
+			<div class="bibliography">
+				<xsl:apply-templates select="*[name()!='head']"/>
+			</div>
+		</div>
+	</xsl:template>
+
+	<xsl:template match="archdesc/*/head">
+		<h3>
+			<xsl:apply-templates/>
+		</h3>
+	</xsl:template>
+
+	<!-- ****************************************************************** -->
+	<!-- Controlled Access headings                                         -->
+	<!-- Formats controlled access headings.  Does NOT handle recursive 	-->
+	<!-- controlaccess elements. Does NOT require HEAD elements (makes for	-->
+	<!-- easier tagging), instead captions are generated.  Subelements      -->
+	<!-- (genreform, etc) do not need to be alphabetized or sorted by type, -->
+	<!-- the style sheet handles this.                                      -->
+	<!-- ****************************************************************** -->
+
+	<!-- top-level entry point -->
+	<xsl:template match="wip-archdesc/controlaccess">
+		<div class="archdesc-section controlaccess">
+			<h3>Indexed Terms</h3>
+			<xsl:apply-templates select="*" mode="top-level"/>
+		</div>
+	</xsl:template>
+
+	<!-- compoent-level entry point and formatting -->
+	<xsl:template match="dsc//controlaccess">
+		<p class="controlaccess">
+			<span class="label">Indexed Terms:</span>
+			<ul class="subject-headings">
+				<xsl:apply-templates select="subject[1] | title[1]  |
+				persname[1]  | famname[1]  | corpname[1]  |
+				geogname[1]  | genreform[1]  | occupation[1]  |
+				function[1]" mode="component"/>
+			</ul>
+		</p>
+	</xsl:template>
+
+	<!-- Group controlaccess elements by type -->
+	<xsl:template match="controlaccess/subject[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Subjects:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::subject"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/title[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Associated Titles:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::title"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/persname[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">People:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::persname"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/famname[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Family Names:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::famname"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/corpname[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Corporate Bodies:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::corpname"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/geogname[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Places:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::geogname"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/genreform[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Genre and Forms:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::genreform"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/occupation[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Occupations:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::occupation"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/function[1]" mode="component">
+		<li class="subj-label">
+			<span class="label">Functions:</span>
+			<ul class="subject-value">
+				<xsl:apply-templates select="../child::function"/>
+			</ul>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="controlaccess/*">
+		<li>
+			<xsl:apply-templates/>
+		</li>
+	</xsl:template>
+
+	<xsl:template match="archdesc/controlaccess">
+		<div class="archdesc-section controlaccess">
+		<h3>Indexed Terms</h3>
+		<ul class="subject-headings">
+			<xsl:for-each select=".">
+				<xsl:if test="persname | famname">
+					<li class="subj-label">
+						<h5>Persons</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="famname | persname">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+				<xsl:if test="corpname">
+					<li class="subj-label">
+						<h5>Corporate Bodies</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="corpname">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+				<xsl:if test="title">
+					<li class="subj-label">
+						<h5>Associated Titles</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="title">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+				<xsl:if test="subject">
+					<li class="subj-label">
+						<h5>Subjects</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="subject">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+				<xsl:if test="geogname">
+					<li class="subj-label">
+						<h5>Places</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="geogname">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+				<xsl:if test="genreform">
+					<li class="subj-label">
+						<h5>Genres and Forms</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="genreform">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+				<xsl:if test="occupation | function">
+					<li class="subj-label">
+						<h5>Occupations</h5>
+						<ul class="subj-values">
+							<xsl:for-each select="occupation | function">
+								<xsl:sort select="." data-type="text" order="ascending"/>
+								<li>
+									<xsl:apply-templates/>
+								</li>
+							</xsl:for-each>
+						</ul>
+					</li>
+				</xsl:if>
+			</xsl:for-each>
+		</ul>
+		</div>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- Access and Use Restriction processing                              -->
+	<!-- Inclused processing of any NOTE child elements.                    -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template name="archdesc-restrict">
+		<xsl:if test="string(archdesc/userestrict/*)
+		or string(archdesc/accessrestrict/*)">
+			<div class="archdesc-section restrict">
+				<h3>
+					<xsl:text>Restrictions</xsl:text>
+				</h3>
+
+				<div class="accessrestrict">
+					<xsl:apply-templates select="archdesc/accessrestrict"/>
+				</div>
+
+				<div class="userrestrict">
+					<xsl:apply-templates select="archdesc/userestrict"/>
+				</div>
+			</div>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="archdesc/accessrestrict/head |
+			     archdesc/userestrict/head">
+		<h4><xsl:apply-templates/>:
+		</h4>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- Other Admin Info processing                                        -->
+	<!-- Inclused processing of any other administrative information        -->
+	<!-- elements and consolidates them into one block under a common       -->
+	<!-- heading, "Administrative Information."  If child elements contain  -->
+	<!-- a HEAD element it is retained and used as the section title.       -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template name="archdesc-admininfo">
+		<xsl:if test="string(archdesc/admininfo/custodhist/*)
+		or string(archdesc/altformavail/*)
+		or string(archdesc/prefercite/*)
+		or string(archdesc/acqinfo/*)
+		or string(archdesc/processinfo/*)
+		or string(archdesc/appraisal/*)
+		or string(archdesc/accruals/*)
+		or string(archdesc/*/custodhist/*)
+		or string(archdesc/*/altformavail/*)
+		or string(archdesc/*/prefercite/*)
+		or string(archdesc/*/acqinfo/*)
+		or string(archdesc/*/processinfo/*)
+		or string(archdesc/*/appraisal/*)
+		or string(archdesc/*/accruals/*)">
+			<div class="archdesc-section admininfo">
+				<h3>
+					<xsl:text>Administrative Information</xsl:text>
+				</h3>
+
+				<xsl:apply-templates select="archdesc/custodhist
+				| archdesc/*/custodhist"/>
+				<xsl:apply-templates select="archdesc/altformavail
+				| archdesc/*/altformavail"/>
+				<xsl:apply-templates select="archdesc/prefercite
+				| archdesc/*/prefercite"/>
+				<xsl:apply-templates select="archdesc/acqinfo
+				| archdesc/*/acqinfo"/>
+				<xsl:apply-templates select="archdesc/processinfo
+				| archdesc/*/processinfo"/>
+				<xsl:apply-templates select="archdesc/admininfo/appraisal
+				| archdesc/*/appraisal"/>
+				<xsl:apply-templates select="archdesc/admininfo/accruals
+				| archdesc/*/accruals"/>
+			</div>
+		</xsl:if>
+	</xsl:template>
+
+
+	<!-- ****************************************************************** -->
+	<!-- INVENTORY LIST PROCESSING	<dsc> & <cxx>                           -->
+	<!-- Now we get into the actual box/folder listings			            -->
+	<!-- ****************************************************************** -->
+
+	<xsl:template match="archdesc/dsc">
+		<div class="archdesc-section dsc">
+			<h3>
+				<xsl:choose>
+					<xsl:when test="dsc/head">
+						<xsl:value-of select="head"/>
+					</xsl:when>
+					<xsl:otherwise>
+						Collection Inventory
+					</xsl:otherwise>
+				</xsl:choose>
+			</h3>
+			<xsl:apply-templates/>
+		</div>
+	</xsl:template>
+
+	<xsl:template match="c | c01 | c02 | c03 | c04 | c05 | c06 | c07 | c08 | c09 | c10 | c11 | c12">
+		<div>
+			<xsl:attribute name="class">component <xsl:value-of select="name()"/>
+			</xsl:attribute>
+
+			<div class="box-folder">
+				<xsl:apply-templates select="did" mode="container"/>
+			</div>
+
+			<div class="component-info">
+				<!-- Change the order below to change printed order -->
+				<xsl:apply-templates select="did"/>
+				<xsl:apply-templates select="scopecontent"/>
+				<xsl:apply-templates select="bioghist"/>
+				<xsl:apply-templates select="processinfo"/>
+				<xsl:apply-templates select="phystech"/>
+				<xsl:apply-templates select="acqinfo"/>
+				<xsl:apply-templates select="custodhist"/>
+				<xsl:apply-templates select="originalsloc"/>
+				<xsl:apply-templates select="arrangement"/>
+				<xsl:apply-templates select="relatedmaterial"/>
+				<xsl:apply-templates select="separatedmaterial"/>
+				<xsl:apply-templates select="prefercite"/>
+				<xsl:apply-templates select="controlaccess"/>
+				<xsl:apply-templates select="otherfindaid"/>
+				<xsl:apply-templates select="odd"/>
+				<xsl:apply-templates select="altformavail"/>
+				<xsl:apply-templates select="accessrestrict"/>
+				<xsl:apply-templates select="userestrict"/>
+			</div>
+
+		</div> <!-- container -->
+		<xsl:apply-templates select="c01 | c02 | c03 | c04 | c05 | c06 | c07 | c08 | c09 | c10 | c11 | c12"/>
+	</xsl:template>
+
+	<xsl:template match="did" mode="container">
+		<xsl:for-each select="container">
+			<xsl:if test="position() > 1">
+				<br/>
+			</xsl:if>
+			<xsl:apply-templates select="@type"/>
+			<xsl:text> </xsl:text>
+			<xsl:apply-templates select="text() | *"/>
+		</xsl:for-each>
+	</xsl:template>
+
+	<xsl:template match="dsc//accessrestrict | dsc//acqinfo | dsc//altformavail | dsc//arrangement | dsc//bioghist |
+		dsc/c01/custodhist | dsc//odd | dsc//originalsloc | dsc//otherfindaid | dsc//prefercite | dsc//processinfo |
+		dsc//phystech | dsc//relatedmaterial | dsc//scopecontent | dsc//separatedmaterial | dsc//userestrict">
+		<p>
+			<!-- embed the <head> text in the first paragraph and process the remaining contents fromm p[1] -->
+			<span class="label">
+				<xsl:apply-templates select="head"/>
+				<xsl:text>: </xsl:text>
+			</span>
+			<xsl:apply-templates select="p[1]/text() | p[1]/*"/>
+		</p>
+		<!-- Process other child nodes - exclude head and p[1] because they've been handled above -->
+		<xsl:apply-templates select="*[(not(self::head) and not(self::p))] | child::p[position()>1] "/>
+	</xsl:template>
+
+	<xsl:template match="dsc//did">
+		<xsl:apply-templates select="../@level"/>
+		<div>
+			<xsl:attribute name="class">unittitle <xsl:value-of select="../@level"/>
+			</xsl:attribute>
+			<xsl:apply-templates select="unittitle"/>
+			<xsl:apply-templates select="unitdate[1]"/>
+		</div>
+		<xsl:apply-templates select="unitid[@type or (count(..//unitid[@type])=0 and position()=1)]"/>
+		<!-- Julie H 2024-10-10 - adding component level origination -->
+		<xsl:apply-templates select="origination"/>
+		<xsl:apply-templates select="physdesc"/>
+		<xsl:apply-templates select="langmaterial"/>
+	</xsl:template>
+
+	<xsl:template match="dsc//unittitle">
+		<xsl:apply-templates/>
+		<xsl:if test="../unitdate">
+			<xsl:text>,</xsl:text>
+			<xsl:value-of select="$space"/>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="dsc//did/unitid">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text> No(s): </xsl:text>
+			</span>
+			<xsl:apply-templates select="node()"/>
+		</p>
+	</xsl:template>
+
+	<!-- Julie H 2024-10-10 - selecting @label and content within origination (often within <persname>); 2024-10-28 - adding colon and space after label -->
+	<xsl:template match="dsc//did/origination">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@label"/><xsl:text>: </xsl:text>
+			</span>
+			<xsl:apply-templates/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="dsc//did/physdesc[not(child::dimensions or child::extent)]">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text>Physical Description: </xsl:text>
+			</span>
+			<xsl:apply-templates/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="did/physdesc/dimensions">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text>Dimensions: </xsl:text>
+			</span>
+			<xsl:apply-templates select="node()"/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="did/physdesc/extent">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text>Quantity: </xsl:text>
+			</span>
+			<xsl:apply-templates select="node()"/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="dsc//did/langmaterial">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text>Language: </xsl:text>
+			</span>
+			<xsl:apply-templates select="node()"/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="attribute::level">
+		<xsl:choose>
+			<xsl:when test="../@level='series'">
+				<h4 class="label">
+					Series:
+				</h4>
+			</xsl:when>
+			<xsl:when test="../@level='subseries'">
+				<h4 class="label">
+					Subseries:
+				</h4>
+			</xsl:when>
+		</xsl:choose>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/bin/web
+++ b/bin/web
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+exec "bundle exec rails s -b 0.0.0.0 -p 3000"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       labels:
         {{- include "chart.labels" . | nindent 8 }}
-	    {{- with .Values.podLabels }}
+      {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -72,6 +72,9 @@ spec:
             - mountPath: /home/app/webapp/public/system
               name: shared
               subPath: system
+            - mountPath: /home/app/webapp/public/html
+              name: shared
+              subPath: html
           {{- end }}
           envFrom:
             - configMapRef:

--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -19,7 +19,7 @@ sample_unitid:
     # size_accessor: 'level'
 default:
   disabled: true
-  pdf:
-    template: 'http://example.com/%{unitid}.pdf'
+  printable_view:
+    template: '/html/%{eadid}.html'
   ead:
-    template: 'http://example.com/%{unitid}.xml'
+    template: '/ead/%{eadid}.xml'


### PR DESCRIPTION
## 🚧 Configure the printable view for downloads

f10276b4c082d485fccfdce057afe4d52e890203

This commit will bring in some changes to make the printable view show
up.  It is a WIP because currently we have nothing to download.

Ref:
- https://github.com/notch8/archives_online/issues/111

## 🚧 Copy over files from Archives Online main

9a39e4c877841a9810e30c88e1577504688a8c96

This commit will copy over print.scss, ead_processor.rb, and the
template.xslt as is with no changes straight from main.

## 🚧 Modify print.scss and ead_processor.rb

1deec85ca1672ddd72544b2748ed0655ec064c62

This commit will alter the original print.scss and ead_processor.rb from
Archives Online main.  The screen styles weren't getting applied so I'm
moving it into the base ead-print style.  Also, adding some logic in the
EadProcessor to ensure that we are getting the same html file name as
the id of the document.

## 🎁 Add convert ead to html command in index.rake

31d269197d95f5eed57779940c899e9f122a2dcf

This commit will add the convert ead to html command to the index.rake.

## 🤖 Add volume for `/home/app/webapp/public/html`

2176d642fbcbbf5654ff62a1bae7ee319b513d6e

This is commit will add a volume for `/home/app/webapp/public/html` in
the deployment.yaml file, so the html versions of the EADs will persist
between deploys.

<img width="1476" alt="image" src="https://github.com/user-attachments/assets/9a2bdebf-d284-435c-b1d2-cf356571e7e1" />
