### PR TITLE
🎁 Prepend "Series" and "Subseries" to title

### DIFF
--- a/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
@@ -1,0 +1,54 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to prepend "Series: " and "Subseries: " to the hierarchy list
+%>
+
+<%= content_tag :li,
+  id: "#{@document.id}-hierarchy-item",
+  data: {
+    'document-id': @document.id.to_s.parameterize,
+    'document-counter': @counter,
+  },
+  itemscope: true,
+  itemtype: @document.itemtype,
+  class: (classes.flatten + ['al-collection-context', ('al-hierarchy-highlight' if current_target?)].compact).join(' ') do %>
+  <div class="documentHeader" data-document-id="<%= document.id %>">
+    <% if document.children? %>
+      <%= link_to('',
+          "#collapsible-hierarchy-#{document.id}",
+          class: "al-toggle-view-children#{ ' collapsed' unless show_expanded?}",
+          aria: {
+            label: t('arclight.hierarchy.view_all'),
+            expanded: show_expanded?
+          },
+          data: {
+            bs_toggle: 'collapse',
+            toggle: 'collapse'
+          }
+        )
+      %>
+    <% end %>
+    <div class="index_title document-title-heading" data-turbo="false">
+      <% if current_target? %>
+        <%= level_label(document.normalized_title) %> <%# OVERRIDE here %>
+      <% else %>
+        <%= level_label(helpers.link_to_document document, counter: @counter) %> <%# OVERRIDE here %>
+      <% end %>
+      <% if document.children? %>
+        <span class="badge badge-pill bg-secondary badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only visually-hidden"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>
+      <% end %>
+      <%= online_status %>
+    </div>
+    <%= content_tag('div', class: 'al-document-container text-muted') do %>
+      <%= document.containers.join(', ') %>
+    <% end if document.containers.present? %>
+  </div>
+
+  <%= render Arclight::IndexMetadataFieldComponent.with_collection(@presenter&.field_presenters.select { |field| field.field_config.collection_context }, classes: ['col pl-0 my-0']) %>
+  <% if document.number_of_children > 0 %>
+    <%= content_tag(:div, id: "collapsible-hierarchy-#{document.id}",
+      class: "collapse al-collection-context-collapsible al-hierarchy-level-#{document.component_level} #{'show' if show_expanded?}"
+    ) do %>
+      <%= render Arclight::DocumentComponentsHierarchyComponent.new(document: @document, target_index: target_index) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.rb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0 to add Series and Subseries to the title
+
+module Ngao
+  module Arclight
+    class DocumentCollectionHierarchyComponent < ::Arclight::DocumentCollectionHierarchyComponent
+      def level_label(content)
+        return content unless %w[Series Subseries].include?(document.level)
+
+        level = "#{document.level}: "
+        level_html = "<span class=\"text-nowrap text-muted\">#{level}</span>"
+        return "#{level_html}#{content}".html_safe unless content.start_with?('<a')
+
+        doc = Nokogiri::HTML.fragment(content)
+        link_element = doc.at_css('a')
+        original_content = link_element.content
+        link_element.content = ''
+        link_element.add_child("#{level_html}#{original_content}")
+
+        doc.to_html.html_safe
+      end
+    end
+  end
+end

--- a/app/views/catalog/hierarchy.html.erb
+++ b/app/views/catalog/hierarchy.html.erb
@@ -1,0 +1,23 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to render `Ngao::Arclight::DocumentCollectionHierarchyComponent`
+%>
+
+<p><%= params[:id] %></p>
+<%= turbo_frame_tag "al-hierarchy-#{params[:id]}#{params[:key]}" do %>
+  <%= render partial: "paginate_compact", object: @response if show_pagination? && params[:paginate] %>
+  <% presenters = @response.documents.map{ | document | document_presenter(document) } %>
+  <% if params[:hierarchy].present? %>
+    <ul class="documents">
+      <%= render Ngao::Arclight::DocumentCollectionHierarchyComponent.with_collection(presenters,
+                                                                                blacklight_config: blacklight_config,
+                                                                                nest_path: params[:nest_path]) %>
+    </ul>
+  <% else %>
+    <table class="table table-striped">
+      <%= render Arclight::DocumentCollectionContextComponent.with_collection(presenters,
+                                                                              blacklight_config: blacklight_config) %>
+    </table>
+  <% end %>
+
+  <%= render 'results_pagination' if params[:paginate] %>
+<% end %>


### PR DESCRIPTION
This commit will prepend the "Series" and "Subseries" level to the title for the hierarchy list.

Ref:
- https://github.com/notch8/archives_online/issues/106

<img width="885" alt="image" src="https://github.com/user-attachments/assets/677d0d43-fb79-4456-ba2b-6e7615666b2c" />
