### PR TITLE
🎁 Standardizes Terminology in More Info Dropdown

### DIFF
--- a/app/components/ngao/arclight/collection_info_component.html.erb
+++ b/app/components/ngao/arclight/collection_info_component.html.erb
@@ -12,7 +12,7 @@
       <table style="width: 100%">
       <%# OVERRIDE - collection_id removed %>
         <tr>
-          <th scope="row"><%= t('.total_components') %></th>
+          <th scope="row"><%= t('.total_items') %></th>
           <td><%= total_component_count %></td>
         </tr>
         <tr>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -80,3 +80,5 @@ en:
     arclight:
       collection_context_component:
         collection_id: Collection ID
+      collection_info_component:
+        total_items: Total Items


### PR DESCRIPTION
# Story: [i105] Standardizing Terminology in More Info Dropdown

Ref:
- https://github.com/notch8/archives_online/issues/105

## Expected Behavior Before Changes

The More Info dropdown had the terms `Collections` and `Items`

## Expected Behavior After Changes

The More Info dropdown uses only the term `Items`

## Screenshots / Video

<details>
<summary>Before</summary>

![Screenshot 2025-04-17 at 11 31 43 AM](https://github.com/user-attachments/assets/57245e56-563c-4c96-a941-960f18e5e093)

</details>

<details>
<summary>After</summary>

![Screenshot 2025-04-17 at 11 25 32 AM](https://github.com/user-attachments/assets/fc6fe20a-42b1-4c78-9c61-02b5ff0a2ab9)

</details>