### PR TITLE
i115 update header text

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -18,8 +18,7 @@
           </div>
           <!-- Website or application title -->
           <div class="rvt-lockup__body">
-            <span class="rvt-lockup__title">Next Generation Archives Online</span>
-            <span class="rvt-lockup__subtitle">Indiana University</span>
+            <span class="rvt-lockup__title">Indiana University</span>
           </div>
         </a>
       </div>


### PR DESCRIPTION
# Story: [i115] Update Header Text

Ref:
- https://github.com/notch8/archives_online/issues/115

## Expected Behavior Before Changes

The top navigation section had a header that said `Next Generation Archives Online` and a subheader that said `Indiana University`.

## Expected Behavior After Changes

The top navigation section will only have a header that says `Indiana University`. The subheader has been removed.

## Screenshots / Video

<details>
<summary>Before</summary>

![Screenshot 2025-04-17 at 11 43 42 AM](https://github.com/user-attachments/assets/c0e8e243-85d8-4888-b143-c1e7d4bc0c2d)

</details>

<details>
<summary>After</summary>

![Screenshot 2025-04-17 at 11 51 29 AM](https://github.com/user-attachments/assets/eda3378d-3052-4b5d-9ba1-37c1c4c80f20)

</details>