### PR TITLE
[i108] follow up - removes display of duplicate creator content

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -185,7 +185,6 @@ class CatalogController < ApplicationController
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }, compact: true, component: Arclight::IndexMetadataFieldComponent
-    config.add_index_field 'creator', accessor: true, component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'breadcrumbs', accessor: :itself,
                                           component: Ngao::Arclight::SearchResultBreadcrumbsComponent,
                                           compact: { count: 2 }


### PR DESCRIPTION
Removes the 'creator' index field from catalog controller to fix duplication issue: A user would see the same data twice when performing a catalog search.

Issue:
- #108

Original PR:
- https://github.com/notch8/archives_online/pull/131

## BEFORE

![image](https://github.com/user-attachments/assets/7d96a2a4-cf5d-415b-b0b9-9d01fa50007a)


## AFTER

<img width="1117" alt="image" src="https://github.com/user-attachments/assets/7a9a7a8d-35d0-4922-b201-b0ac6925092b" />
