### PR TITLE
🎁 [i95] - Make hierarchy components clickable if extra metadata exists

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -80,3 +80,13 @@ body {
     }
   }
 }
+
+// Style the title of the currently selected hierarchy item to look like a link
+.al-hierarchy-highlight {
+  .documentHeader {
+    .al-collection-context-item-title {
+      color: var(--link-color, $link-color);
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/components/ngao/arclight/collection_context_component.html.erb
+++ b/app/components/ngao/arclight/collection_context_component.html.erb
@@ -14,7 +14,6 @@
 
     <div class="al-collection-context-actions d-flex flex-wrap gap-1">
       <%= document_download %>
-      <%= collection_info %>
     </div>
   </div>
 </div>

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
@@ -1,5 +1,6 @@
 <%#
   OVERRIDE Arclight v1.4.0 to prepend "Series: " and "Subseries: " to the hierarchy list
+  OVERRIDE Arclight v1.4.0 to render link to document if extra metadata exists, and to render the title as a span if no extra metadata exists
 %>
 
 <%= content_tag :li,
@@ -28,10 +29,17 @@
       %>
     <% end %>
     <div class="index_title document-title-heading" data-turbo="false">
+      <%# OVERRIDE - conditionally render link to document if extra metadata exists - start%>
       <% if current_target? %>
-        <%= level_label(document.normalized_title) %> <%# OVERRIDE here %>
+        <span class="al-collection-context-item-title"><%= level_label(document.normalized_title) %></span>
       <% else %>
-        <%= level_label(helpers.link_to_document document, counter: @counter) %> <%# OVERRIDE here %>
+        <% has_extra_metadata = helpers.component_has_extra_metadata?(document, helpers.blacklight_config) %>
+        <% if has_extra_metadata %>
+          <%= level_label(helpers.link_to_document document, counter: @counter) %>
+        <% else %>
+          <span class="al-collection-context-item-title"><%= level_label(document.normalized_title) %></span>
+        <% end %>
+        <%# OVERRIDE end %>
       <% end %>
       <% if document.children? %>
         <span class="badge badge-pill bg-secondary badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only visually-hidden"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -6,6 +6,7 @@ class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include Arclight::Catalog
   include Arclight::FieldConfigHelpers
+  include Ngao::ComponentMetadataHelper
 
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index

--- a/app/helpers/ngao/component_metadata_helper.rb
+++ b/app/helpers/ngao/component_metadata_helper.rb
@@ -3,44 +3,54 @@
 module Ngao
   # Helper methods for determining component metadata presence
   module ComponentMetadataHelper
-    # Checks if a SolrDocument for an archival component has metadata fields
+    # Checks if a SolrDocument or Presenter for an archival component has metadata fields
     # populated beyond title and containers, based on configured component fields.
     #
-    # @param document [SolrDocument]
+    # @param document [SolrDocument, Blacklight::DocumentPresenter]
     # @param blacklight_config [Blacklight::Configuration]
     # @return [Boolean]
     def component_has_extra_metadata?(document, blacklight_config)
       blacklight_config.component_fields.values.any? do |field_config|
-        next false if field_config.accessor == :containers || field_config.field == :containers
+        next false if field_is_container?(field_config)
 
-        field_name = solr_field_name_for_config(field_config)
+        field_name = extract_field_name(field_config)
         next false unless field_name
 
-        field_value_present?(document, field_name)
+        check_document_field(document, field_name)
       end
     end
 
     private
 
-    # Determines the Solr field name to check based on the field configuration.
-    # @param field_config [Blacklight::Configuration::Field]
-    # @return [String, Symbol, nil]
-    def solr_field_name_for_config(field_config)
-      field_config.field || (if field_config.accessor.is_a?(String) || field_config.accessor.is_a?(Symbol)
-                               field_config.accessor
-                             end)
+    def field_is_container?(field_config)
+      field_config.try(:accessor) == :containers || field_config.try(:field) == :containers
     end
 
-    # Checks if the document has the specified field and if the value is present and non-empty.
-    # Handles single values, arrays, nil, and empty strings gracefully.
-    # @param document [SolrDocument]
-    # @param field_name [String, Symbol]
-    # @return [Boolean]
-    def field_value_present?(document, field_name)
-      value = document[field_name.to_s]
+    def extract_field_name(field_config)
+      field_name = field_config.try(:field)
+      return field_name if field_name
 
-      value.present? &&
-        (!value.respond_to?(:all?) || value.all?(&:present?))
+      accessor = field_config.try(:accessor)
+      accessor if accessor.is_a?(String) || accessor.is_a?(Symbol)
+    end
+
+    def check_document_field(document, field_name)
+      doc_value = document[field_name.to_s]
+      value_present_and_non_empty?(doc_value)
+    rescue StandardError => e
+      log_field_access_error(document, field_name, e)
+      false
+    end
+
+    def value_present_and_non_empty?(value)
+      value.present? && (!value.respond_to?(:all?) || value.all?(&:present?))
+    end
+
+    def log_field_access_error(document, field_name, error)
+      Rails.logger.error(
+        "[ComponentMetadataHelper] Error accessing field #{field_name} " \
+        "on document #{document&.id}: #{error.message}"
+      )
     end
   end
 end

--- a/app/helpers/ngao/component_metadata_helper.rb
+++ b/app/helpers/ngao/component_metadata_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Ngao
+  # Helper methods for determining component metadata presence
+  module ComponentMetadataHelper
+    # Checks if a SolrDocument for an archival component has metadata fields
+    # populated beyond title and containers, based on configured component fields.
+    #
+    # @param document [SolrDocument]
+    # @param blacklight_config [Blacklight::Configuration]
+    # @return [Boolean]
+    def component_has_extra_metadata?(document, blacklight_config)
+      blacklight_config.component_fields.values.any? do |field_config|
+        next false if field_config.accessor == :containers || field_config.field == :containers
+
+        field_name = solr_field_name_for_config(field_config)
+        next false unless field_name
+
+        field_value_present?(document, field_name)
+      end
+    end
+
+    private
+
+    # Determines the Solr field name to check based on the field configuration.
+    # @param field_config [Blacklight::Configuration::Field]
+    # @return [String, Symbol, nil]
+    def solr_field_name_for_config(field_config)
+      field_config.field || (if field_config.accessor.is_a?(String) || field_config.accessor.is_a?(Symbol)
+                               field_config.accessor
+                             end)
+    end
+
+    # Checks if the document has the specified field and if the value is present and non-empty.
+    # Handles single values, arrays, nil, and empty strings gracefully.
+    # @param document [SolrDocument]
+    # @param field_name [String, Symbol]
+    # @return [Boolean]
+    def field_value_present?(document, field_name)
+      value = document[field_name.to_s]
+
+      value.present? &&
+        (!value.respond_to?(:all?) || value.all?(&:present?))
+    end
+  end
+end


### PR DESCRIPTION
Improves the user experience in the collection hierarchy (side-by-side) view by addressing confusion caused by clickable components that lack detailed information beyond title and container.

Previously, components were clickable even if they only contained `<unittitle>` and `<container>` metadata. Since container information is usually visible in the sidebar, clicking these components led to a redundant detail view showing no new information.

This PR implements the following changes:

- Components in the collection hierarchy (`Ngao::Arclight::DocumentCollectionHierarchyComponent`) are now only rendered as links (clickable) if they possess metadata fields beyond `<unittitle>` and `<container>`.
- A new helper method (`Ngao::ComponentMetadataHelper.component_has_extra_metadata?`) was added to determine if a component has such extra metadata, checking against the fields configured in `CatalogController`.
- Components lacking extra metadata are rendered as plain text (using their `normalized_title`), preventing unnecessary navigation while still displaying the title. Container info remains visible in the sidebar.
- The "More Info" button (displaying total/online items and index date) has been removed from the collection context header in the sidebar (`Ngao::Arclight::CollectionContextComponent`) as requested, reducing clutter.
- Maintains the look of a hyperlink once the component is clicked.

This aligns the hierarchy's interactive elements with user expectations, making navigation more intuitive and reducing redundant clicks.

⚠️ NOTE - I attempted to add a spec but I'm coming across one error after the next when running it, so something may be wrong with the [test set up](https://github.com/notch8/archives_online/pull/138). This will be addressed in a separate issue/PR. 

Issue:
- #95

## BEFORE

<details> 

#### "More Info" button is present but not helpful: 

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/a2443824-618b-4046-97f7-28abd621760d" />

#### All components are clickable links despite if there's more details available: 

<img width="517" alt="image" src="https://github.com/user-attachments/assets/719fb408-7706-4dbf-ae6d-7fce49cefbb4" />

</details>

## AFTER

<details>

#### Removed "More Info" button: 

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/07e955e9-91a0-4b99-87b2-8200028b8681" />


#### Only components with additional metadata should display as a link: 

<img width="471" alt="image" src="https://github.com/user-attachments/assets/2d1bf7e7-3925-49d2-b26f-c7d9b7d5af10" />

#### Maintain hyperlink once clicked

<img width="468" alt="image" src="https://github.com/user-attachments/assets/e5f66285-1679-432d-81e8-4bf6f8ca7b67" />

</details>