### PR TITLE
🐛 Add missing styles to printable view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ yarn-debug.log*
 
 /public/html
 /public/ead
+.sass-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN /sbin/setuser app bash -l -c " \
     cd /home/app/webapp && \
     yarn install && \
     NODE_ENV=production DB_ADAPTER=nulldb bundle exec rake assets:precompile"
-RUN cp ./app/assets/stylesheets/print.scss ./public/assets/print.scss
+
+RUN mkdir -p ./public/assets
+RUN bundle exec sass ./app/assets/stylesheets/print.scss ./public/assets/print.scss
 
 CMD ["/sbin/my_init"]

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem 'mysql2'
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 5.0'
 
+# Used for the printable view
+gem 'sass'
+
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis (4.8.1)
@@ -385,6 +388,11 @@ GEM
       rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -527,6 +535,7 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rake
   rubocop-rspec_rails
+  sass
   sassc-rails (~> 2.1)
   selenium-webdriver
   sentry-rails


### PR DESCRIPTION
This commit will add the missing styles for the printable view.  We needed the `bundle exec sass` command.

Ref:
- https://github.com/notch8/archives_online/issues/111

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/be7ff194-e073-4eed-81b2-458a47e4f31e" />
