### PR TITLE
i147 sidebar independent scroll

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -25,6 +25,16 @@ body {
   }
 }
 
+// OVERRIDE Blacklight v8.9.0 to allow sidebar to scroll independently of the finding aid content
+#sidebar {
+  @media (min-width: 992px) {
+    position: sticky;
+    top: 0;
+    height: calc(100vh - 5rem);
+    overflow-y: auto;
+  }
+}
+
 // OVERRIDE Arclight v1.4.0 to remove padding on the left of the header
 .al-masthead .h1 {
   padding-left: 0;


### PR DESCRIPTION
# Story: [i147] Allow sidebar to scroll independently of the main content

Ref:
- https://github.com/notch8/archives_online/issues/147

## Expected Behavior Before Changes

The sidebar and main content scrolled as a single entity.

## Expected Behavior After Changes

The sidebar scrolls independently of the main content.

## Screenshots / Video

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/cdd02cc5-b661-47e5-a779-ff89f388406c


</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/32201493-e027-4b99-a52c-a1ac9e7f6a6d


</details>