### PR TITLE
replace sass with sassc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ RUN /sbin/setuser app bash -l -c " \
     NODE_ENV=production DB_ADAPTER=nulldb bundle exec rake assets:precompile"
 
 RUN mkdir -p ./public/assets
-RUN bundle exec sass ./app/assets/stylesheets/print.scss ./public/assets/print.scss
+RUN bundle exec ruby -rsassc -e "puts SassC::Engine.new(File.read('./app/assets/stylesheets/print.scss'), syntax: :scss).render" > ./public/assets/print.css
 
 CMD ["/sbin/my_init"]

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'mysql2'
 gem 'puma', '~> 5.0'
 
 # Used for the printable view
-gem 'sass'
+gem 'sassc'
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,9 +310,6 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis (4.8.1)
@@ -388,11 +385,6 @@ GEM
       rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -535,7 +527,7 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rake
   rubocop-rspec_rails
-  sass
+  sassc
   sassc-rails (~> 2.1)
   selenium-webdriver
   sentry-rails

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -17,6 +17,12 @@
 
 replicaCount: 1
 
+podSecurityContext:
+  runAsUser: 1001
+  runAsGroup: 101
+  fsGroup: 101
+  fsGroupChangePolicy: "OnRootMismatch"
+
 image:
   repository: ghcr.io/notch8/archives_online:latest
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Original PR that introduced a deprecated gem, sass
- https://github.com/notch8/archives_online/pull/170/files

This PR replaces it with a non deprecated option to support styles for print. 

Issue: 
- https://github.com/notch8/archives_online/issues/111

![image](https://github.com/user-attachments/assets/026334c1-5f49-437f-8813-54ce049aaa91)
