### PR TITLE
i176 remove tools section

### DIFF
--- a/app/components/ngao/arclight/sidebar_component.html.erb
+++ b/app/components/ngao/arclight/sidebar_component.html.erb
@@ -1,0 +1,14 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to remove the tools section from the sidebar
+%>
+
+<div class="offcanvas-lg offcanvas-start p-3 p-lg-1" tabindex="-1" id="sidebar">
+  <%= collection_context %>
+  <%# OVERRIDE remove the tools section %>
+  <%#= render (blacklight_config.show.show_tools_component || Blacklight::Document::ShowToolsComponent).new(document: document) %>
+  <%= collection_sidebar %>
+  <div id="collection-context" class="sidebar-section">
+    <h2><%= t('arclight.views.show.has_content') %></h2>
+    <%= turbo_frame_tag "al-hierarchy-#{document.root}", loading: 'lazy', src: hierarchy_solr_document_path(id: document.root, nest_path: @document.nest_path, hierarchy: true) %>
+  </div>
+</div>


### PR DESCRIPTION
# Story: [i176] Remove tools section from the sidebar

Ref:
- https://github.com/notch8/archives_online/issues/176

## Expected Behavior Before Changes

The tools section was in the sidebar under the collection details.

## Expected Behavior After Changes

The tools section was removed.

## Screenshots / Video

<details>
<summary>Before</summary>

![Screenshot 2025-04-21 at 2 45 04 PM](https://github.com/user-attachments/assets/99804e54-f130-49b3-b645-dcff44472956)

</details>

<details>
<summary>After</summary>

![Screenshot 2025-04-21 at 2 42 02 PM](https://github.com/user-attachments/assets/31b936ce-24fc-4af1-a5fc-9abda68ced13)

</details>