### PR TITLE
🎁 Favor Dart Sass for Rails over Sass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ RUN /sbin/setuser app bash -l -c " \
     NODE_ENV=production DB_ADAPTER=nulldb bundle exec rake assets:precompile"
 
 RUN mkdir -p ./public/assets
-RUN bundle exec sass ./app/assets/stylesheets/print.scss ./public/assets/print.scss
+RUN bundle exec dartsass ./app/assets/stylesheets/print.scss ./public/assets/print.scss --style=compressed
 
 CMD ["/sbin/my_init"]

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'mysql2'
 gem 'puma', '~> 5.0'
 
 # Used for the printable view
-gem 'sass'
+gem 'dartsass-rails'
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,9 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.4)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.0)
@@ -168,6 +171,9 @@ GEM
       rake
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.30.2-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
     gretel (5.0.1)
       actionview (>= 6.1)
       railties (>= 6.1)
@@ -310,9 +316,6 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis (4.8.1)
@@ -388,11 +391,8 @@ GEM
       rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sass-embedded (1.86.3-aarch64-linux-gnu)
+      google-protobuf (~> 4.30)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -514,6 +514,7 @@ DEPENDENCIES
   bootstrap (~> 5.1)
   capybara
   coveralls
+  dartsass-rails
   database_cleaner
   database_cleaner-active_record
   debug
@@ -535,7 +536,6 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rake
   rubocop-rspec_rails
-  sass
   sassc-rails (~> 2.1)
   selenium-webdriver
   sentry-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,7 @@
  *
  *= require_tree .
  *= require_self
- 
+
  *
  * Used by blacklight_range_limit
  *= require  'blacklight_range_limit'


### PR DESCRIPTION
This commit will remove the depracted Sass gem in favor of using Dart Sass for Rails.

Ref:
- https://github.com/notch8/archives_online/issues/174