### PR TITLE
i103 container info in collection context

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -100,3 +100,16 @@ body {
     }
   }
 }
+
+// OVERRIDE Arclight v1.4.0 to add the container information to the collection context
+#collection-context .al-document-container {
+  display: block;
+}
+
+.document.al-collection-context {
+  .documentHeader {
+    .document-title-heading {
+      width: 100%;
+    }
+  }
+}

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
@@ -45,10 +45,10 @@
         <span class="badge badge-pill bg-secondary badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only visually-hidden"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>
       <% end %>
       <%= online_status %>
+      <%= content_tag('div', class: 'al-document-container text-muted') do %>
+        <%= document.containers.join(', ') %>
+      <% end if document.containers.present? %>
     </div>
-    <%= content_tag('div', class: 'al-document-container text-muted') do %>
-      <%= document.containers.join(', ') %>
-    <% end if document.containers.present? %>
   </div>
 
   <%= render Arclight::IndexMetadataFieldComponent.with_collection(@presenter&.field_presenters.select { |field| field.field_config.collection_context }, classes: ['col pl-0 my-0']) %>


### PR DESCRIPTION
# Story: [i103] Add physical container information to the collection context in the sidebar

Ref:
- https://github.com/notch8/archives_online/issues/103

## Expected Behavior Before Changes

The physical container information was only available on the show page of each item.

## Expected Behavior After Changes

The physical container information is in the sidebar next to each item's title.

## Screenshots / Video

<details>
<summary>Before</summary>

![Screenshot 2025-04-21 at 4 21 48 PM](https://github.com/user-attachments/assets/555592d5-72a8-4b69-aedb-75c749879c92)

</details>
<details>
<summary>After</summary>

![Screenshot 2025-04-22 at 9 31 57 AM](https://github.com/user-attachments/assets/e38d1f1c-8760-4fdb-a30c-8c449e4fcba4)

</details>