### PR TITLE
🧹 {i95] - Maintain blue hyperlink style for collapsible components

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -95,8 +95,25 @@ body {
 .al-hierarchy-highlight {
   .documentHeader {
     .al-collection-context-item-title {
-      color: var(--link-color, $link-color);
+      color: #006298;
       text-decoration: underline;
+    }
+  }
+}
+
+li:not(.al-hierarchy-highlight) {
+  .documentHeader {
+    .al-hierarchy-parent-title {
+      color: #006298;
+      text-decoration: underline;
+    }
+  }
+}
+
+li:not(.al-hierarchy-highlight) {
+  .documentHeader {
+    a {
+      color: #006298;
     }
   }
 }

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
@@ -34,8 +34,11 @@
         <span class="al-collection-context-item-title"><%= level_label(document.normalized_title) %></span>
       <% else %>
         <% has_extra_metadata = helpers.component_has_extra_metadata?(document, helpers.blacklight_config) %>
+        <% has_children = document.children? %>
         <% if has_extra_metadata %>
           <%= level_label(helpers.link_to_document document, counter: @counter) %>
+        <% elsif has_children %>
+          <span class="al-collection-context-item-title al-hierarchy-parent-title"><%= level_label(document.normalized_title) %></span>
         <% else %>
           <span class="al-collection-context-item-title"><%= level_label(document.normalized_title) %></span>
         <% end %>

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.rb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.rb
@@ -9,7 +9,7 @@ module Ngao
         return content unless %w[Series Subseries].include?(document.level)
 
         level = "#{document.level}: "
-        level_html = "<span class=\"text-nowrap text-muted\">#{level}</span>"
+        level_html = "<span class=\"text-nowrap\">#{level}</span>"
         return "#{level_html}#{content}".html_safe unless content.start_with?('<a')
 
         doc = Nokogiri::HTML.fragment(content)


### PR DESCRIPTION


## BEFORE

<img width="422" alt="image" src="https://github.com/user-attachments/assets/95328fb3-fd15-4005-9dee-8314ffaaca0a" />


## AFTER

![Zight Recording 2025-04-22 at 08 58 15 AM](https://github.com/user-attachments/assets/5897c316-7230-4054-84bb-89c0d2ae159f)
