### PR TITLE
I113 aeon integration

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -33,6 +33,10 @@ body {
     height: calc(100vh - 5rem);
     overflow-y: auto;
   }
+
+  .al-request-button {
+    height: 35px;
+  }
 }
 
 // OVERRIDE Arclight v1.4.0 to remove padding on the left of the header

--- a/app/components/ngao/arclight/collection_context_component.html.erb
+++ b/app/components/ngao/arclight/collection_context_component.html.erb
@@ -1,6 +1,8 @@
 <%#
   OVERRIDE Arclight v1.4.0 to add the collection unitid
   @see: Ngao::Arclight::CollectionContextComponent
+
+  Also to add the Aeon request button
 %>
 
 <div class="al-show-actions-box mb-3">
@@ -15,6 +17,7 @@
     <div class="al-collection-context-actions d-flex flex-wrap gap-1">
       <%= document_download %>
       <%= collection_info %>
+      <%= render 'arclight/requests', document: collection %>
     </div>
   </div>
 </div>

--- a/app/components/ngao/arclight/document_component.html.erb
+++ b/app/components/ngao/arclight/document_component.html.erb
@@ -3,6 +3,7 @@
   @see: Ngao::Arclight::DocumentComponent
 
   Also to, render normlized_html_title
+  Also to, remove Aeon request button
 %>
 
 <div class='d-md-flex justify-content-between al-show'>
@@ -17,7 +18,7 @@
   <%= content_tag :h1 do %>
     <%= helpers.render_html_tags({ value: document.normalized_title_html }) || document.normalized_title %>
   <% end %>
-  <%= render 'arclight/requests', document: document %>
+  <%#= render 'arclight/requests', document: document %> <%# OVERRIDE, moving it to collection context%>
   <%#= render Arclight::BookmarkComponent.new document: document, action: bookmark_config %>
   <%= toggle_sidebar %>
   <%= online_filter %>

--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -22,4 +22,4 @@ default:
   printable_view:
     template: '/html/%{eadid}.html'
   ead:
-    template: '/ead/%{eadid}.xml'
+    template: 'https://archives.iu.edu/ead/%{eadid}.xml'


### PR DESCRIPTION
## ⚙️ Configure Aeon

1c7ba870787fd9ff99fb6ba3bf7617dea81ab109

This commit will configure Aeon by adding the archives.iu.edu address to
the ead download.  This does make our ead downloads look at the live
site which I think is fine for now since it would theoretically serve
the same content.

Ref:
- https://github.com/notch8/archives_online/issues/113

## 🎁 Move request button to collection context

c9bef3702dd0ce756c78a557838124d82813c00f

This commit will move the Aeon request button to the collection context
area.

Ref:
- https://github.com/notch8/archives_online/issues/113


https://github.com/user-attachments/assets/a4ffaead-8d3c-4f18-9402-ea4f77e396d7

