### PR TITLE
Add custom note labels

### DIFF
--- a/app/components/ngao/blacklight/metadata_field_component_decorator.rb
+++ b/app/components/ngao/blacklight/metadata_field_component_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE Blacklight v8.3.0 to render custom labels when they exist
+# OVERRIDE Blacklight MetadataFieldComponentDecorator v8.3.0 to render custom labels when they exist
 module Ngao
   module Blacklight
     module MetadataFieldComponentDecorator

--- a/app/components/ngao/blacklight/metadata_field_component_decorator.rb
+++ b/app/components/ngao/blacklight/metadata_field_component_decorator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight v8.3.0 to render custom labels when they exist
+module Ngao
+  module Blacklight
+    module MetadataFieldComponentDecorator
+      def label
+        key = @field.key
+        document = @field.document
+        heading_field = "#{key}_heading_ssm"
+
+        label = document[heading_field]&.first
+        return super unless label
+
+        "#{label}:"
+      end
+    end
+  end
+end
+
+Blacklight::MetadataFieldComponent.prepend(Ngao::Blacklight::MetadataFieldComponentDecorator)


### PR DESCRIPTION
Ref https://github.com/notch8/archives_online/issues/148

Overrides the label method to use the indexed <head> term as the label if one exists, with fallback to the prior behavior. 

<details>
<summary>Screenshot Before Change</summary>

![screencapture-archives-online-test-catalog-InU-Li-VAD1572-2025-04-22-14_28_26](https://github.com/user-attachments/assets/3ed58747-5714-4628-9563-341b216fb5b4)

</details>

<details>
<summary>Screenshot After Change</summary>

![screencapture-archives-online-test-catalog-InU-Li-VAD1572-2025-04-22-14_28_49](https://github.com/user-attachments/assets/c40dc689-d6cc-4882-80bc-3c1332dbf08d)

</details>