### PR TITLE
🎁 i184 modifies header links

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -1,5 +1,6 @@
 <%#
-  OVERRIDE Blacklight v8.3.0 to add IU styling and  remove user_util_links
+  OVERRIDE Blacklight v8.3.0 to add IU styling and remove user_util_links
+  Also adds external link to IU homepage
 %>
 
 <!-- Hidden link for keyboard users to skip to main content -->
@@ -9,7 +10,7 @@
   <div class="rvt-container-xl">
     <div class="rvt-header-global__inner">
       <div class="rvt-header-global__logo-slot">
-        <a class="rvt-lockup" href="/">
+        <a class="rvt-lockup" href="https://www.iu.edu/index.html" title="Indiana University" aria-label="Indiana University" target="_blank">
           <!-- Trident logo -->
           <div class="rvt-lockup__tab">
             <svg xmlns="http://www.w3.org/2000/svg" class="rvt-lockup__trident" viewBox="0 0 28 34">

--- a/app/components/ngao/arclight/header_component.rb
+++ b/app/components/ngao/arclight/header_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0
+# - Add a nav link to the Masthead text
+
+module Ngao
+  module Arclight
+    class HeaderComponent < ::Arclight::HeaderComponent
+      def masthead
+        render Ngao::Arclight::MastheadComponent.new
+      end
+    end
+  end
+end

--- a/app/components/ngao/arclight/masthead_component.html.erb
+++ b/app/components/ngao/arclight/masthead_component.html.erb
@@ -1,0 +1,24 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to add a nav link to the masthead text
+  @see: Ngao::Arclight::MastheadComponent
+%>
+
+<div class="al-masthead bg-light">
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="col-md-8">
+      <a href="/" class="text-dark">
+        <div class="h1 my-4 text-center text-md-start"><%= heading %></div>
+        </a>
+      </div>
+
+      <div class="col-md-4">
+        <nav class="navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">
+          <ul class="navbar-nav">
+            <%= render 'shared/main_menu_links' %>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/ngao/arclight/masthead_component.rb
+++ b/app/components/ngao/arclight/masthead_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0
+# Add a nav link to the Masthead text
+
+module Ngao
+  module Arclight
+    class MastheadComponent < ::Arclight::MastheadComponent
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,7 +50,7 @@ class CatalogController < ApplicationController
       'collection.rows': 1
     }
 
-    config.header_component = Arclight::HeaderComponent
+    config.header_component = Ngao::Arclight::HeaderComponent
     config.add_results_document_tool(:online, component: Arclight::OnlineStatusIndicatorComponent)
     ##### REMOVE BOOKMARK #####
     # config.add_results_document_tool(:arclight_bookmark_control, component: Arclight::BookmarkComponent)


### PR DESCRIPTION
# Story: [i184] Modifies Header and Masthead links

Ref:
- https://github.com/notch8/archives_online/issues/184

## Expected Behavior Before Changes

The Indiana University header was an internal nav to the root of the application. The masthead text did not have a link.

## Expected Behavior After Changes

The Indiana University header now navigates to the Indiana homepage: `https://www.iu.edu/index.html` 
The masthead is now an internal nav to the root of the application