### PR TITLE
[hot fix] - partially revert persistent volume deploy

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -63,15 +63,15 @@ spec:
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
-            - mountPath: /home/app/webapp/public/assets-new
-              name: shared
-              subPath: assets
-            - mountPath: /home/app/webapp/public/packs
-              name: shared
-              subPath: packs
-            - mountPath: /home/app/webapp/public/system
-              name: shared
-              subPath: system
+            # - mountPath: /home/app/webapp/public/assets-new
+            #   name: shared
+            #   subPath: assets
+            # - mountPath: /home/app/webapp/public/packs
+            #   name: shared
+            #   subPath: packs
+            # - mountPath: /home/app/webapp/public/system
+            #   name: shared
+            #   subPath: system
             - mountPath: /home/app/webapp/public/html
               name: shared
               subPath: html


### PR DESCRIPTION
mounting assets deploy may have broken staging css. I'm partially reverting the persistent volume changes to include only the ones Kirk needed to support ead printing. 

ref: https://github.com/notch8/archives_online/pull/189

<img width="677" alt="image" src="https://github.com/user-attachments/assets/f68e7a59-6d0f-4eae-8fce-6d5ca0b7430d" />

deploying this branch fixed the above issue: 

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/7358f236-fc64-4fd9-a770-f342c5ccd87e" />
