### PR TITLE
♻️ [i95] - Reverts hyperlink styles

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -99,25 +99,8 @@ body {
 .al-hierarchy-highlight {
   .documentHeader {
     .al-collection-context-item-title {
-      color: #006298;
+      color: var(--link-color, $link-color);
       text-decoration: underline;
-    }
-  }
-}
-
-li:not(.al-hierarchy-highlight) {
-  .documentHeader {
-    .al-hierarchy-parent-title {
-      color: #006298;
-      text-decoration: underline;
-    }
-  }
-}
-
-li:not(.al-hierarchy-highlight) {
-  .documentHeader {
-    a {
-      color: #006298;
     }
   }
 }

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.html.erb
@@ -34,11 +34,8 @@
         <span class="al-collection-context-item-title"><%= level_label(document.normalized_title) %></span>
       <% else %>
         <% has_extra_metadata = helpers.component_has_extra_metadata?(document, helpers.blacklight_config) %>
-        <% has_children = document.children? %>
         <% if has_extra_metadata %>
           <%= level_label(helpers.link_to_document document, counter: @counter) %>
-        <% elsif has_children %>
-          <span class="al-collection-context-item-title al-hierarchy-parent-title"><%= level_label(document.normalized_title) %></span>
         <% else %>
           <span class="al-collection-context-item-title"><%= level_label(document.normalized_title) %></span>
         <% end %>

--- a/app/components/ngao/arclight/document_collection_hierarchy_component.rb
+++ b/app/components/ngao/arclight/document_collection_hierarchy_component.rb
@@ -9,7 +9,7 @@ module Ngao
         return content unless %w[Series Subseries].include?(document.level)
 
         level = "#{document.level}: "
-        level_html = "<span class=\"text-nowrap\">#{level}</span>"
+        level_html = "<span class=\"text-nowrap text-muted\">#{level}</span>"
         return "#{level_html}#{content}".html_safe unless content.start_with?('<a')
 
         doc = Nokogiri::HTML.fragment(content)


### PR DESCRIPTION
Follow up 
Issue
- #95 

This PR reverts a [change](https://github.com/notch8/archives_online/pull/183) I made. I second guessed myself with what the client was asking for when they said to maintain the blue hyperlinks. The solution in staging ended up being too aggressive and my original implementation is preferred, as confirmed by the client: 

@brijmcla if i revert my latest changes this is what we have. Is this correct? 

<details> 

### Example 1

<img width="414" alt="Image" src="https://github.com/user-attachments/assets/20419f8e-a291-4a25-872e-55571dd1a77d" />

### when clicked: 

<img width="1047" alt="Image" src="https://github.com/user-attachments/assets/312b9d7d-019f-43ff-8ffc-d332832e07bf" />


### Example 2

<img width="484" alt="Image" src="https://github.com/user-attachments/assets/ee158c1f-e183-4a30-8d01-2401d02930a6" />

</details> 

<img width="808" alt="image" src="https://github.com/user-attachments/assets/79e477c0-5f35-4a4b-b880-d952bb22dd21" />


## BEFORE

<img width="470" alt="image" src="https://github.com/user-attachments/assets/0efc9e96-8aa6-49e9-a7a8-d9a6b84d97f3" />


