### PR TITLE
🐛 i103 Physical container information on sidebar

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -104,3 +104,17 @@ body {
     }
   }
 }
+
+// OVERRIDE Arclight v1.4.0 to add physical container information to the collection context in the sidebar
+#collection-context .al-document-container {
+  display: block;
+}
+
+// OVERRIDE Arclight v1.4.0 to add physical container information to the collection context in the sidebar
+.document.al-collection-context {
+  .documentHeader {
+    .document-title-heading {
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
# Story: [i103] Physical Description on Sidebar

Ref:
- https://github.com/notch8/archives_online/issues/103

## Expected Behavior Before Changes

Missing styling from a merge conflict.

## Expected Behavior After Changes

Physical collection content is visible in the sidebar.

## Screenshots / Video

<details>
<summary>Collection content sidebar</summary>

![Screenshot 2025-04-23 at 3 00 38 PM](https://github.com/user-attachments/assets/8b1027e7-0975-472d-b133-2947b2502037)

</details>