### PR TITLE
Parses & displays the creators' roles as labels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rdf'
+
 group :development, :test do
   gem 'bixby'
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     base64 (0.2.0)
+    bcp47_spec (0.2.1)
     bcrypt (3.1.20)
     bigdecimal (3.1.9)
     bindex (0.8.1)
@@ -214,6 +215,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    link_header (0.0.8)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
@@ -310,6 +312,10 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdf (3.3.2)
+      bcp47_spec (~> 0.2)
+      bigdecimal (~> 3.1, >= 3.1.5)
+      link_header (~> 0.0, >= 0.0.8)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis (4.8.1)
@@ -518,6 +524,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.1)
   rails-controller-testing
+  rdf
   redis (~> 4.0)
   rsolr (>= 1.0, < 3)
   rspec

--- a/app/components/ngao/blacklight/creator_role_component.html.erb
+++ b/app/components/ngao/blacklight/creator_role_component.html.erb
@@ -1,0 +1,9 @@
+<%# duplicate of MetadataFieldComponent to allow customized Creator Role Rendering %>
+<%= render(@layout.new(field: @field)) do |component| %>
+  <% component.with_label do %>
+    <%= label %>
+  <% end %>
+  <% component.with_value do %>
+  <%= @field.render %>
+  <% end %>
+<% end %>

--- a/app/components/ngao/blacklight/creator_role_component.rb
+++ b/app/components/ngao/blacklight/creator_role_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# OVERRIDE adds a custom role-specific label to the creator field
+module Ngao
+  module Blacklight
+    class CreatorRoleComponent < ::Blacklight::MetadataFieldComponent
+      def label
+        values = @field.values
+        # values is an array containing a JSON string with one or more hash elements
+        # with multiple values possible for each role.
+        # ["[{\"Interviewer\":[\"Stahlman, Joseph\"]}]"]
+        creators_with_roles = JSON.parse(values.first)
+        labels = creators_with_roles.map(&:keys).flatten
+        # we can only show one label, so if there are multiple roles, we just use default
+        label = labels.first if labels.size == 1
+        return super unless label
+
+        "#{label}:"
+      end
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -302,7 +302,7 @@ class CatalogController < ApplicationController
     # ===========================
 
     # Collection Show Page - Summary Section
-    config.add_summary_field 'creators', field: 'creator_ssim', link_to_facet: true
+    config.add_summary_field 'creators', field: 'creator_role_ssim', label: 'Creator', component: Ngao::Blacklight::CreatorRoleComponent, helper_method: :render_creator_links
     config.add_summary_field 'abstract', field: 'abstract_html_tesm', helper_method: :render_html_tags
     config.add_summary_field 'extent', field: 'extent_ssm'
     config.add_summary_field 'language', field: 'language_ssim'
@@ -373,7 +373,7 @@ class CatalogController < ApplicationController
       document.containers.present?
     }
     config.add_component_field 'unitid_ssm', label: 'Component Identifier', helper_method: :render_html_tags
-    config.add_component_field 'creators', field: 'creator_ssim', link_to_facet: true
+    config.add_component_field 'creators', field: 'creator_role_ssim', component: Ngao::Blacklight::CreatorRoleComponent, helper_method: :render_creator_links
     config.add_component_field 'abstract', field: 'abstract_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'extent', field: 'extent_ssm'
     config.add_component_field 'scopecontent', field: 'scopecontent_html_tesm', helper_method: :render_html_tags

--- a/app/helpers/arclight_helper_decorator.rb
+++ b/app/helpers/arclight_helper_decorator.rb
@@ -12,6 +12,16 @@ module ArclightHelperDecorator
       group: true
     )
   end
+
+  def render_creator_links(field)
+    # values is an array containing a JSON string with one or more hash elements
+    # with multiple values possible for each role.
+    # ["[{\"Interviewer\":[\"Stahlman, Joseph\"]}]"]
+    values = field[:value]
+    creators_with_roles = JSON.parse(values.first)
+    creators = creators_with_roles.map(&:values).flatten
+    link_to_name_facet({ config: config, value: creators })
+  end
 end
 
 ArclightHelper.prepend(ArclightHelperDecorator)

--- a/config/relators.nt
+++ b/config/relators.nt
@@ -1,0 +1,4283 @@
+# BEGIN /vocabulary/relators/abr
+
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#code> "abr" .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged. For substantial modifications that result in the creation of a new work, see author"@en .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Abridger" .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/abr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/abr
+
+# BEGIN /vocabulary/relators/acp
+
+<http://id.loc.gov/vocabulary/relators/acp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Art copyist" .
+<http://id.loc.gov/vocabulary/relators/acp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/acp> <http://www.loc.gov/mads/rdf/v1#code> "acp" .
+<http://id.loc.gov/vocabulary/relators/acp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/acp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person (e.g., a painter or sculptor) who makes copies of works of visual art"@en .
+<http://id.loc.gov/vocabulary/relators/acp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/acp
+
+# BEGIN /vocabulary/relators/act
+
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to an expression of a work by acting as a cast member or player in a musical or dramatic presentation, etc."@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/vac> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Actor" .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#code> "act" .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Voice actor" .
+
+# END /vocabulary/relators/act
+
+# BEGIN /vocabulary/relators/adi
+
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed RDA def"@en .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Art director" .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person contributing to a motion picture or television production by overseeing the artists and craftspeople who build the sets"@en .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/adi> <http://www.loc.gov/mads/rdf/v1#code> "adi" .
+
+# END /vocabulary/relators/adi
+
+# BEGIN /vocabulary/relators/adp
+
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.loc.gov/mads/rdf/v1#code> "adp" .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Adapter" .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who 1) reworks a musical composition, usually for a different medium, or 2) rewrites novels or stories for motion pictures or other audiovisual medium."@en .
+<http://id.loc.gov/vocabulary/relators/adp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/adp
+
+# BEGIN /vocabulary/relators/aft
+
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#code> "aft" .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author of afterword, colophon, etc." .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for an afterword, postface, colophon, etc. but who is not the chief author of a work"@en .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/aft
+
+# BEGIN /vocabulary/relators/anl
+
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Analyst" .
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.loc.gov/mads/rdf/v1#code> "anl" .
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that reviews, examines and interprets data or information in a specific area"@en .
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/anl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/anl
+
+# BEGIN /vocabulary/relators/anm
+
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#code> "anm" .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person contributing to a moving image work or computer program by giving apparent movement to inanimate objects or drawings. For the creator of the drawings that are animated, see artist"@en .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Animator" .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/anm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/anm
+
+# BEGIN /vocabulary/relators/ann
+
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#code> "ann" .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Annotator" .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who makes manuscript annotations on an item"@en .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ann> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/ann
+
+# BEGIN /vocabulary/relators/ant
+
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for a resource upon which the resource represented by the bibliographic description is based. This may be appropriate for adaptations, sequels, continuations, indexes, etc."@en .
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Bibliographic antecedent" .
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ant> <http://www.loc.gov/mads/rdf/v1#code> "ant" .
+
+# END /vocabulary/relators/ant
+
+# BEGIN /vocabulary/relators/ape
+
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#code> "ape" .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Appellee" .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#editorialNote> "MARC had more specific roles"@en .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization against whom an appeal is taken"@en .
+<http://id.loc.gov/vocabulary/relators/ape> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+
+# END /vocabulary/relators/ape
+
+# BEGIN /vocabulary/relators/apl
+
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who appeals a lower court's decision"@en .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Appellant" .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#editorialNote> "MARC had more specific roles"@en .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#code> "apl" .
+<http://id.loc.gov/vocabulary/relators/apl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+
+# END /vocabulary/relators/apl
+
+# BEGIN /vocabulary/relators/app
+
+<http://id.loc.gov/vocabulary/relators/app> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/app> <http://www.loc.gov/mads/rdf/v1#code> "app" .
+<http://id.loc.gov/vocabulary/relators/app> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/app> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the submission of an application or who is named as eligible for the results of the processing of the application (e.g., bestowing of rights, reward, title, position)"@en .
+<http://id.loc.gov/vocabulary/relators/app> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/app> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Applicant" .
+<http://id.loc.gov/vocabulary/relators/app> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/app
+
+# BEGIN /vocabulary/relators/aqt
+
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#code> "aqt" .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization whose work is largely quoted or extracted in works to which he or she did not contribute directly. Such quotations are found particularly in exhibition catalogs, collections of photographs, etc."@en .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author in quotations or text abstracts" .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/aqt
+
+# BEGIN /vocabulary/relators/arc
+
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Architect" .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating an architectural design, including a pictorial representation intended to show how a building, etc., will look when completed. It also oversees the construction of structures"@en .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Landscape architect" .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#code> "arc" .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/lsa> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/arc
+
+# BEGIN /vocabulary/relators/ard
+
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Artistic director" .
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person responsible for controlling the development of the artistic style of an entire production, including the choice of works to be presented and selection of senior production staff"@en .
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.loc.gov/mads/rdf/v1#code> "ard" .
+<http://id.loc.gov/vocabulary/relators/ard> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/ard
+
+# BEGIN /vocabulary/relators/arr
+
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#code> "arr" .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def; changed RDA term"@en .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n0fed154975354a8889eb9294ba08e687b1 .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a musical work by rewriting the composition for a medium of performance different from that for which the work was originally intended, or modifying the work for the same medium of performance, etc., such that the musical substance of the original composition remains essentially unchanged. For extensive modification that effectively results in the creation of a new musical work, see composer"@en .
+_:n0fed154975354a8889eb9294ba08e687b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Arranger of music" .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Arranger" .
+_:n0fed154975354a8889eb9294ba08e687b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/arr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/arr
+
+# BEGIN /vocabulary/relators/art
+
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/scl> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#code> "art" .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n2d58ea5d328f4c1aadca1f07554d8c02b1 .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Sculptor" .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+_:n2d58ea5d328f4c1aadca1f07554d8c02b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#editorialNote> "\"changed MARC def; Relator term \"\"Graphic technician\"\" (coded [grt]) used before March 1988 only\""@en .
+_:n2d58ea5d328f4c1aadca1f07554d8c02b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Graphic technician" .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a work by conceiving, and implementing, an original graphic design, drawing, painting, etc. For book illustrators, prefer Illustrator [ill]"@en .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Artist" .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+
+# END /vocabulary/relators/art
+
+# BEGIN /vocabulary/relators/asg
+
+<http://id.loc.gov/vocabulary/relators/asg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/asg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Assignee" .
+<http://id.loc.gov/vocabulary/relators/asg> <http://www.loc.gov/mads/rdf/v1#code> "asg" .
+<http://id.loc.gov/vocabulary/relators/asg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/asg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization to whom a license for printing or publishing has been transferred"@en .
+<http://id.loc.gov/vocabulary/relators/asg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/asg
+
+# BEGIN /vocabulary/relators/asn
+
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Associated name" .
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.loc.gov/mads/rdf/v1#code> "asn" .
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization associated with or found in an item or collection, which cannot be determined to be that of a Former owner [fmo] or other designated relationship indicative of provenance"@en .
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/asn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/asn
+
+# BEGIN /vocabulary/relators/ato
+
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#code> "ato" .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person whose manuscript signature appears on an item"@en .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Autographer" .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ato> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/ato
+
+# BEGIN /vocabulary/relators/att
+
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n434206b406a748f9be6a666ef40a572db1 .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#code> "att" .
+_:n434206b406a748f9be6a666ef40a572db1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Attributed name" .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An author, artist, etc., relating him/her to a resource for which there is or once was substantial authority for designating that person as author, creator, etc. of the work indicative of provenance"@en .
+<http://id.loc.gov/vocabulary/relators/att> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+_:n434206b406a748f9be6a666ef40a572db1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Supposed name" .
+
+# END /vocabulary/relators/att
+
+# BEGIN /vocabulary/relators/auc
+
+<http://id.loc.gov/vocabulary/relators/auc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Auctioneer" .
+<http://id.loc.gov/vocabulary/relators/auc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization in charge of the estimation and public auctioning of goods, particularly books, artistic works, etc."@en .
+<http://id.loc.gov/vocabulary/relators/auc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/auc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/auc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/auc> <http://www.loc.gov/mads/rdf/v1#code> "auc" .
+
+# END /vocabulary/relators/auc
+
+# BEGIN /vocabulary/relators/aud
+
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#code> "aud" .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author of dialog" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the dialog or spoken commentary for a screenplay or sound recording"@en .
+
+# END /vocabulary/relators/aud
+
+# BEGIN /vocabulary/relators/aui
+
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for an introduction, preface, foreword, or other critical introductory matter, but who is not the chief author"@en .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#code> "aui" .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author of introduction, etc." .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/aui
+
+# BEGIN /vocabulary/relators/aus
+
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Screenwriter" .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+_:na34456f16502401a839df3bf6861faa1b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Author of screenplay, etc." .
+_:na34456f16502401a839df3bf6861faa1b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An author of a screenplay, script, or scene"@en .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:na34456f16502401a839df3bf6861faa1b1 .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#code> "aus" .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/aus
+
+# BEGIN /vocabulary/relators/aut
+
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Screenwriter" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/aus> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Librettist" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/aud> .
+<http://id.loc.gov/vocabulary/relators/aus> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+_:n6891a0b4f18d4f7a9720d67db896f579b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Joint author" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/lbt> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/aft> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author of afterword, colophon, etc." .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/aui> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n6891a0b4f18d4f7a9720d67db896f579b1 .
+_:n6891a0b4f18d4f7a9720d67db896f579b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a work that is primarily textual in content, regardless of media type (e.g., printed text, spoken word, electronic text, tactile text) or genre (e.g., poems, novels, screenplays, blogs). Use also for persons, etc., creating a new work by paraphrasing, rewriting, or adapting works by another creator such that the modification has substantially changed the nature and content of the original or changed the medium of expression"@en .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aud> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author of dialog" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#code> "aut" .
+<http://id.loc.gov/vocabulary/relators/aqt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author in quotations or text abstracts" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/lyr> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/aft> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Lyricist" .
+<http://id.loc.gov/vocabulary/relators/aui> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author of introduction, etc." .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/aqt> .
+
+# END /vocabulary/relators/aut
+
+# BEGIN /vocabulary/relators/bdd
+
+_:ne32560a5c23b4189a423e808cc4a10d9b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.loc.gov/mads/rdf/v1#code> "bdd" .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the binding design of a book, including the type of binding, the type of materials used, and any decorative aspects of the binding"@en .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:ne32560a5c23b4189a423e808cc4a10d9b1 .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Binding designer" .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/bdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+_:ne32560a5c23b4189a423e808cc4a10d9b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Designer of binding" .
+
+# END /vocabulary/relators/bdd
+
+# BEGIN /vocabulary/relators/bjd
+
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n91173e05f86c4382a9b4407e384c73dfb1 .
+_:n91173e05f86c4382a9b4407e384c73dfb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Designer of bookjacket" .
+_:n91173e05f86c4382a9b4407e384c73dfb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the design of flexible covers designed for or published with a book, including the type of materials used, and any decorative aspects of the bookjacket"@en .
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Bookjacket designer" .
+<http://id.loc.gov/vocabulary/relators/bjd> <http://www.loc.gov/mads/rdf/v1#code> "bjd" .
+
+# END /vocabulary/relators/bjd
+
+# BEGIN /vocabulary/relators/bkd
+
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:ndbb1a5b5e2b441339ba99c139488862fb1 .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+_:ndbb1a5b5e2b441339ba99c139488862fb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:ndbb1a5b5e2b441339ba99c139488862fb2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization involved in manufacturing a manifestation by being responsible for the entire graphic design of a book, including arrangement of type and illustration, choice of materials, and process used"@en .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#code> "bkd" .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Book designer" .
+_:ndbb1a5b5e2b441339ba99c139488862fb2 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Designer of e-book" .
+<http://id.loc.gov/vocabulary/relators/bkd> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:ndbb1a5b5e2b441339ba99c139488862fb2 .
+_:ndbb1a5b5e2b441339ba99c139488862fb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Designer of book" .
+
+# END /vocabulary/relators/bkd
+
+# BEGIN /vocabulary/relators/bkp
+
+_:n45ec52959f424a038ffc485df7628f82b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Producer of book" .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n45ec52959f424a038ffc485df7628f82b1 .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Book producer" .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n45ec52959f424a038ffc485df7628f82b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the production of books and other print media"@en .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/bkp> <http://www.loc.gov/mads/rdf/v1#code> "bkp" .
+
+# END /vocabulary/relators/bkp
+
+# BEGIN /vocabulary/relators/blw
+
+<http://id.loc.gov/vocabulary/relators/blw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/blw> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for writing a commendation or testimonial for a work, which appears on or within the publication itself, frequently on the back or dust jacket of print publications or on advertising material for all media"@en .
+<http://id.loc.gov/vocabulary/relators/blw> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Blurb writer" .
+<http://id.loc.gov/vocabulary/relators/blw> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/blw> <http://www.loc.gov/mads/rdf/v1#code> "blw" .
+<http://id.loc.gov/vocabulary/relators/blw> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/blw
+
+# BEGIN /vocabulary/relators/bnd
+
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who binds an item"@en .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Binder" .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/bnd> <http://www.loc.gov/mads/rdf/v1#code> "bnd" .
+
+# END /vocabulary/relators/bnd
+
+# BEGIN /vocabulary/relators/bpd
+
+<http://id.loc.gov/vocabulary/relators/bpd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bpd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/bpd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/bpd> <http://www.loc.gov/mads/rdf/v1#code> "bpd" .
+<http://id.loc.gov/vocabulary/relators/bpd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Bookplate designer" .
+<http://id.loc.gov/vocabulary/relators/bpd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the design of a book owner's identification label that is most commonly pasted to the inside front cover of a book"@en .
+
+# END /vocabulary/relators/bpd
+
+# BEGIN /vocabulary/relators/brd
+
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in broadcasting a resource to an audience via radio, television, webcast, etc."@en .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAPublisher> .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#code> "brd" .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Broadcaster" .
+<http://id.loc.gov/vocabulary/relators/brd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/brd
+
+# BEGIN /vocabulary/relators/brl
+
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Braille embosser" .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#code> "brl" .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/brl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in manufacturing a resource by embossing Braille cells using a stylus, special embossing printer, or other device"@en .
+
+# END /vocabulary/relators/brl
+
+# BEGIN /vocabulary/relators/bsl
+
+<http://id.loc.gov/vocabulary/relators/bsl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who makes books and other bibliographic materials available for purchase. Interest in the materials is primarily lucrative"@en .
+<http://id.loc.gov/vocabulary/relators/bsl> <http://www.loc.gov/mads/rdf/v1#code> "bsl" .
+<http://id.loc.gov/vocabulary/relators/bsl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/bsl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Bookseller" .
+<http://id.loc.gov/vocabulary/relators/bsl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/bsl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/bsl
+
+# BEGIN /vocabulary/relators/cas
+
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#code> "cas" .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in manufacturing a resource by pouring a liquid or molten substance into a mold and leaving it to solidify to take the shape of the mold"@en .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Caster" .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cas> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+
+# END /vocabulary/relators/cas
+
+# BEGIN /vocabulary/relators/ccp
+
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.loc.gov/mads/rdf/v1#code> "ccp" .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Conceptor" .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ccp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the original idea on which a work is based, this includes the scientific author of an audio-visual item and the conceptor of an advertisement"@en .
+
+# END /vocabulary/relators/ccp
+
+# BEGIN /vocabulary/relators/chr
+
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#code> "chr" .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Choreographer" .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person responsible for creating or contributing to a work of movement"@en .
+<http://id.loc.gov/vocabulary/relators/chr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/chr
+
+# BEGIN /vocabulary/relators/clb
+
+_:n3b949d41bc794f51b8047d27c9567105b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.loc.gov/mads/rdf/v1#deprecatedLabel> "Collaborator" .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n3b949d41bc794f51b8047d27c9567105b1 .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.loc.gov/mads/rdf/v1#code> "clb" .
+_:n3b949d41bc794f51b8047d27c9567105b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Contributor" .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority> .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/clb> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Combined with Contributor (ctb)"@en .
+
+# END /vocabulary/relators/clb
+
+# BEGIN /vocabulary/relators/cli
+
+<http://id.loc.gov/vocabulary/relators/cli> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cli> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cli> <http://www.loc.gov/mads/rdf/v1#code> "cli" .
+<http://id.loc.gov/vocabulary/relators/cli> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cli> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Client" .
+<http://id.loc.gov/vocabulary/relators/cli> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization for whom another person or organization is acting"@en .
+
+# END /vocabulary/relators/cli
+
+# BEGIN /vocabulary/relators/cll
+
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who writes in an artistic hand, usually as a copyist and or engrosser"@en .
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Calligrapher" .
+<http://id.loc.gov/vocabulary/relators/cll> <http://www.loc.gov/mads/rdf/v1#code> "cll" .
+
+# END /vocabulary/relators/cll
+
+# BEGIN /vocabulary/relators/clr
+
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Colorist" .
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.loc.gov/mads/rdf/v1#code> "clr" .
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for applying color to drawings, prints, photographs, maps, moving images, etc"@en .
+<http://id.loc.gov/vocabulary/relators/clr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/clr
+
+# BEGIN /vocabulary/relators/clt
+
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Collotyper" .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#code> "clt" .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in manufacturing a manifestation of photographic prints from film or other colloid that has ink-receptive and ink-repellent surfaces"@en .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/clt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/clt
+
+# BEGIN /vocabulary/relators/cmm
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Commentator" .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#code> "cmm" .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a work by providing interpretation, analysis, or a discussion of the subject matter on a recording, film, or other audiovisual medium"@en .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/cmm
+
+# BEGIN /vocabulary/relators/cmp
+
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Composer" .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#code> "cmp" .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def; combines RDA terms"@en .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating or contributing to a musical resource by adding music to a work that originally lacked it or supplements it"@en .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/cmp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/cmp
+
+# BEGIN /vocabulary/relators/cmt
+
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+_:n7892f6ab7bd84fdb90c2e918c7fa49a4b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Typesetter" .
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the creation of metal slug, or molds made of other materials, used to produce the text and images in printed matter"@en .
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Compositor" .
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.loc.gov/mads/rdf/v1#code> "cmt" .
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n7892f6ab7bd84fdb90c2e918c7fa49a4b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/cmt> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n7892f6ab7bd84fdb90c2e918c7fa49a4b1 .
+
+# END /vocabulary/relators/cmt
+
+# BEGIN /vocabulary/relators/cnd
+
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a musical resource by leading a performing group (orchestra, chorus, opera, etc.) in a musical or dramatic presentation, etc."@en .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#code> "cnd" .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Conductor" .
+
+# END /vocabulary/relators/cnd
+
+# BEGIN /vocabulary/relators/cng
+
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+_:n56a27fc01033421b864fad60f9c09b0ab1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Director of photography" .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#code> "cng" .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#sourceNote> "FIAF"@en .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person in charge of photographing a motion picture, who plans the technical aspets of lighting and photographing of scenes, and often assists the director in the choice of angles, camera setups, and lighting moods. He or she may also supervise the further processing of filmed material up to the completion of the work print. Cinematographer is also referred to as director of photography. Do not confuse with videographer"@en .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+_:n56a27fc01033421b864fad60f9c09b0ab1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n56a27fc01033421b864fad60f9c09b0ab1 .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Cinematographer" .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def (FIAF); RDA uses for videographer and MARC differentiates (confirmed with Andrea Leigh)"@en .
+<http://id.loc.gov/vocabulary/relators/cng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/cng
+
+# BEGIN /vocabulary/relators/cns
+
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n12c2dc62019b46c9974806f6edc1c178b2 .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def (not RDA)"@en .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n12c2dc62019b46c9974806f6edc1c178b1 .
+_:n12c2dc62019b46c9974806f6edc1c178b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#code> "cns" .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Censor" .
+_:n12c2dc62019b46c9974806f6edc1c178b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Expurgator" .
+_:n12c2dc62019b46c9974806f6edc1c178b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cns> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who examines bibliographic resources for the purpose of suppressing parts deemed objectionable on moral, political, military, or other grounds"@en .
+_:n12c2dc62019b46c9974806f6edc1c178b2 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Bowdlerizer" .
+
+# END /vocabulary/relators/cns
+
+# BEGIN /vocabulary/relators/coe
+
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant-appellee" .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant" .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A contestant against whom an appeal is taken from one court of law or jurisdiction to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cos> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#code> "coe" .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/coe
+
+# BEGIN /vocabulary/relators/col
+
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#code> "col" .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Collector" .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Curator" .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cur> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A curator who brings together items from various sources that are then arranged, described, and cataloged as a collection. A collector is neither the creator of the material nor a person to whom manuscripts in the collection may have been addressed"@en .
+
+# END /vocabulary/relators/col
+
+# BEGIN /vocabulary/relators/com
+
+<http://id.loc.gov/vocabulary/relators/com> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#code> "com" .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc"@en .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/com> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Compiler" .
+
+# END /vocabulary/relators/com
+
+# BEGIN /vocabulary/relators/con
+
+<http://id.loc.gov/vocabulary/relators/con> <http://www.loc.gov/mads/rdf/v1#code> "con" .
+<http://id.loc.gov/vocabulary/relators/con> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Conservator" .
+<http://id.loc.gov/vocabulary/relators/con> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n326699ba9057421396d92fe09e4bea8eb1 .
+<http://id.loc.gov/vocabulary/relators/con> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/con> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+_:n326699ba9057421396d92fe09e4bea8eb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/con> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/con> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for documenting, preserving, or treating printed or manuscript material, works of art, artifacts, or other media"@en .
+_:n326699ba9057421396d92fe09e4bea8eb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Preservationist" .
+
+# END /vocabulary/relators/con
+
+# BEGIN /vocabulary/relators/cor
+
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#code> "cor" .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A curator who lists or inventories the items in an aggregate work such as a collection of items or works"@en .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Curator" .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cur> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Collection registrar" .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/cor
+
+# BEGIN /vocabulary/relators/cos
+
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant-appellant" .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#code> "cos" .
+<http://id.loc.gov/vocabulary/relators/coe> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant-appellee" .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant" .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/coe> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person(s) or organization who opposes, resists, or disputes, in a court of law, a claim, decision, result, etc."@en .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cot> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/cos
+
+# BEGIN /vocabulary/relators/cot
+
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A contestant who takes an appeal from one court of law or jurisdiction to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant-appellant" .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestant" .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cos> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#code> "cot" .
+<http://id.loc.gov/vocabulary/relators/cot> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cos> .
+
+# END /vocabulary/relators/cot
+
+# BEGIN /vocabulary/relators/cou
+
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Court governed" .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#code> "cou" .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cou> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A court governed by court rules, regardless of their official nature (e.g., laws, administrative regulations)"@en .
+
+# END /vocabulary/relators/cou
+
+# BEGIN /vocabulary/relators/cov
+
+_:n6813158164784d5ebdacfacd247a957bb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Designer of cover" .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.loc.gov/mads/rdf/v1#code> "cov" .
+_:n6813158164784d5ebdacfacd247a957bb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the graphic design of a book cover, album cover, slipcase, box, container, etc. For a person or organization responsible for the graphic design of an entire book, use Book designer; for book jackets, use Bookjacket designer"@en .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n6813158164784d5ebdacfacd247a957bb1 .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cov> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Cover designer" .
+
+# END /vocabulary/relators/cov
+
+# BEGIN /vocabulary/relators/cpc
+
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.loc.gov/mads/rdf/v1#code> "cpc" .
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Copyright claimant" .
+<http://id.loc.gov/vocabulary/relators/cpc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization listed as a copyright owner at the time of registration. Copyright can be granted or later transferred to another person or organization, at which time the claimant becomes the copyright holder"@en .
+
+# END /vocabulary/relators/cpc
+
+# BEGIN /vocabulary/relators/cpe
+
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant" .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A complainant against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#code> "cpe" .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cpl> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant-appellee" .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/cpe
+
+# BEGIN /vocabulary/relators/cph
+
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.loc.gov/mads/rdf/v1#code> "cph" .
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Copyright holder" .
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cph> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization to whom copy and legal rights have been granted or transferred for the intellectual content of a work. The copyright holder, although not necessarily the creator of the work, usually has the exclusive right to benefit financially from the sale and use of the work to which the associated copyright protection applies"@en .
+
+# END /vocabulary/relators/cph
+
+# BEGIN /vocabulary/relators/cpl
+
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who applies to the courts for redress, usually in an equity proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant" .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cpe> .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cpt> .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant-appellant" .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#code> "cpl" .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpe> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant-appellee" .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/cpl
+
+# BEGIN /vocabulary/relators/cpt
+
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant" .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A complainant who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Complainant-appellant" .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cpl> .
+<http://id.loc.gov/vocabulary/relators/cpl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cpt> <http://www.loc.gov/mads/rdf/v1#code> "cpt" .
+
+# END /vocabulary/relators/cpt
+
+# BEGIN /vocabulary/relators/cre
+
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Creator" .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the intellectual or artistic content of a resource"@en .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/creator> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#code> "cre" .
+<http://id.loc.gov/vocabulary/relators/cre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+
+# END /vocabulary/relators/cre
+
+# BEGIN /vocabulary/relators/crp
+
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who was either the writer or recipient of a letter or other communication"@en .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Correspondent" .
+<http://id.loc.gov/vocabulary/relators/crp> <http://www.loc.gov/mads/rdf/v1#code> "crp" .
+
+# END /vocabulary/relators/crp
+
+# BEGIN /vocabulary/relators/crr
+
+<http://id.loc.gov/vocabulary/relators/crr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/crr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/crr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is a corrector of manuscripts, such as the scriptorium official who corrected the work of a scribe. For printed matter, use Proofreader"@en .
+<http://id.loc.gov/vocabulary/relators/crr> <http://www.loc.gov/mads/rdf/v1#code> "crr" .
+<http://id.loc.gov/vocabulary/relators/crr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Corrector" .
+<http://id.loc.gov/vocabulary/relators/crr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/crr
+
+# BEGIN /vocabulary/relators/crt
+
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by preparing a court’s opinions for publication"@en .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#code> "crt" .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Court reporter" .
+<http://id.loc.gov/vocabulary/relators/crt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+
+# END /vocabulary/relators/crt
+
+# BEGIN /vocabulary/relators/csl
+
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization relevant to a resource, who is called upon for professional advice or services in a specialized field of knowledge or training"@en .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#code> "csl" .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Consultant" .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/csl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/csl
+
+# BEGIN /vocabulary/relators/csp
+
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Consultant to a project" .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.loc.gov/mads/rdf/v1#code> "csp" .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization relevant to a resource, who is engaged specifically to provide an intellectual overview of a strategic or operational task and by analysis, specification, or instruction, to create or propose a cost-effective course of action or solution"@en .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/csp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/csp
+
+# BEGIN /vocabulary/relators/cst
+
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization that designs the costumes for a moving image production or for a musical or dramatic presentation or entertainment"@en .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Costume designer" .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#code> "cst" .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/cst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/cst
+
+# BEGIN /vocabulary/relators/ctb
+
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family or organization responsible for making contributions to the resource. This includes those whose work has been contributed to a larger work, such as an anthology, serial publication, or other compilation of individual works. If a more specific role is available, prefer that, e.g. editor, compiler, illustrator"@en .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#code> "ctb" .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def; Collaborator deprecated in MARC list and reference made"@en .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contributor" .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+_:nadd008d8f5bb4b31b34aac3feec2285fb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:nadd008d8f5bb4b31b34aac3feec2285fb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Collaborator" .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nadd008d8f5bb4b31b34aac3feec2285fb1 .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/ctb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/ctb
+
+# BEGIN /vocabulary/relators/cte
+
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee" .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A contestee against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee-appellee" .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#code> "cte" .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cts> .
+
+# END /vocabulary/relators/cte
+
+# BEGIN /vocabulary/relators/ctg
+
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a map, atlas, globe, or other cartographic work"@en .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#code> "ctg" .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Cartographer" .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ctg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+
+# END /vocabulary/relators/ctg
+
+# BEGIN /vocabulary/relators/ctr
+
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization relevant to a resource, who enters into a contract with another person or organization to perform a specific"@en .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contractor" .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.loc.gov/mads/rdf/v1#code> "ctr" .
+<http://id.loc.gov/vocabulary/relators/ctr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/ctr
+
+# BEGIN /vocabulary/relators/cts
+
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee" .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#code> "cts" .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/ctt> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cte> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person(s) or organization defending a claim, decision, result, etc. being opposed, resisted, or disputed in a court of law"@en .
+<http://id.loc.gov/vocabulary/relators/cte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee-appellee" .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee-appellant" .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/cts
+
+# BEGIN /vocabulary/relators/ctt
+
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee" .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A contestee who takes an appeal from one court or jurisdiction to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/cts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Contestee-appellant" .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#code> "ctt" .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ctt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/cts> .
+
+# END /vocabulary/relators/ctt
+
+# BEGIN /vocabulary/relators/cur
+
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+_:n83605580277c433ca895659ec313a654b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#code> "cur" .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization conceiving, aggregating, and/or organizing an exhibition, collection, or other item"@en .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cor> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n83605580277c433ca895659ec313a654b1 .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/col> .
+<http://id.loc.gov/vocabulary/relators/col> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Collector" .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Curator" .
+_:n83605580277c433ca895659ec313a654b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Curator of an exhibition" .
+<http://id.loc.gov/vocabulary/relators/cor> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Collection registrar" .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cur> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/cur
+
+# BEGIN /vocabulary/relators/cwt
+
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.loc.gov/mads/rdf/v1#code> "cwt" .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the commentary or explanatory notes about a text. For the writer of manuscript annotations in a printed book, use Annotator"@en .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Commentator for written text" .
+<http://id.loc.gov/vocabulary/relators/cwt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/cwt
+
+# BEGIN /vocabulary/relators/dbp
+
+<http://id.loc.gov/vocabulary/relators/dbp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A place from which a resource, e.g., a serial, is distributed"@en .
+<http://id.loc.gov/vocabulary/relators/dbp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dbp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Distribution place" .
+<http://id.loc.gov/vocabulary/relators/dbp> <http://www.loc.gov/mads/rdf/v1#code> "dbp" .
+<http://id.loc.gov/vocabulary/relators/dbp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dbp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/dbp
+
+# BEGIN /vocabulary/relators/dfd
+
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant" .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#code> "dfd" .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/dft> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is accused in a criminal proceeding or sued in a civil proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant-appellant" .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant-appellee" .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/dfe> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/dfd
+
+# BEGIN /vocabulary/relators/dfe
+
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A defendant against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in a legal action"@en .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#code> "dfe" .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant" .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/dfd> .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dfe> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant-appellee" .
+
+# END /vocabulary/relators/dfe
+
+# BEGIN /vocabulary/relators/dft
+
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant" .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A defendant who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in a legal action"@en .
+<http://id.loc.gov/vocabulary/relators/dfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#code> "dft" .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/dfd> .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Defendant-appellant" .
+<http://id.loc.gov/vocabulary/relators/dft> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/dft
+
+# BEGIN /vocabulary/relators/dgg
+
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Degree granting institution" .
+_:n263ec518053d487aa242c986fee26e57b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n263ec518053d487aa242c986fee26e57b1 .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A organization granting an academic degree"@en .
+_:n263ec518053d487aa242c986fee26e57b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Degree grantor" .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#code> "dgg" .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dgg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+
+# END /vocabulary/relators/dgg
+
+# BEGIN /vocabulary/relators/dgs
+
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person overseeing a higher level academic degree"@en .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Degree supervisor" .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/dgs> <http://www.loc.gov/mads/rdf/v1#code> "dgs" .
+
+# END /vocabulary/relators/dgs
+
+# BEGIN /vocabulary/relators/dis
+
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who presents a thesis for a university or higher-level educational degree"@en .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.loc.gov/mads/rdf/v1#code> "dis" .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dis> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Dissertant" .
+
+# END /vocabulary/relators/dis
+
+# BEGIN /vocabulary/relators/dln
+
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization executing technical drawings from others' designs"@en .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Delineator" .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.loc.gov/mads/rdf/v1#code> "dln" .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dln> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/dln
+
+# BEGIN /vocabulary/relators/dnc
+
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Dancer" .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#code> "dnc" .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer who dances in a musical, dramatic, etc., presentation"@en .
+
+# END /vocabulary/relators/dnc
+
+# BEGIN /vocabulary/relators/dnr
+
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOwner> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Former owner" .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Donor" .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/fmo> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A former owner of an item who donated that item to another owner"@en .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#code> "dnr" .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/dnr
+
+# BEGIN /vocabulary/relators/dpc
+
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Depicted" .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/subject> .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An entity depicted or portrayed in a work, particularly in a work of art"@en .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#code> "dpc" .
+<http://id.loc.gov/vocabulary/relators/dpc> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Subject relationship"@en .
+
+# END /vocabulary/relators/dpc
+
+# BEGIN /vocabulary/relators/dpt
+
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOwner> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Owner" .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Depositor" .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A current owner of an item who deposited the item into the custody of another person, family, or organization, while still retaining ownership"@en .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#code> "dpt" .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/own> .
+
+# END /vocabulary/relators/dpt
+
+# BEGIN /vocabulary/relators/drm
+
+_:na1b9e7de416541628ecf98e9a918020ab1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Technical draftsman" .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by an architect, inventor, etc., by making detailed plans or drawings for buildings, ships, aircraft, machines, objects, etc"@en .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#code> "drm" .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+_:na1b9e7de416541628ecf98e9a918020ab1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Draftsman" .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/drm> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:na1b9e7de416541628ecf98e9a918020ab1 .
+
+# END /vocabulary/relators/drm
+
+# BEGIN /vocabulary/relators/drt
+
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/rdd> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Director" .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/fmd> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film director" .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/tld> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Television director" .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/fmk> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#code> "drt" .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Radio director" .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Filmmaker" .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person responsible for the general management and supervision of a filmed performance, a radio or television program, etc."@en .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/drt
+
+# BEGIN /vocabulary/relators/dsr
+
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Designer" .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a design for an object"@en .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#code> "dsr" .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/dsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+
+# END /vocabulary/relators/dsr
+
+# BEGIN /vocabulary/relators/dst
+
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/fds> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that has exclusive or shared marketing rights for a resource"@en .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Distributor" .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film distributor" .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/publisher> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prv> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Provider" .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#code> "dst" .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/dst
+
+# BEGIN /vocabulary/relators/dtc
+
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.loc.gov/mads/rdf/v1#code> "dtc" .
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that submits data for inclusion in a database or other collection of data"@en .
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Data contributor" .
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dtc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/dtc
+
+# BEGIN /vocabulary/relators/dte
+
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Dedicatee" .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+_:nb0d5787c23ba479dbc3e53e326ec3953b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nb0d5787c23ba479dbc3e53e326ec3953b1 .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization to whom a resource is dedicated"@en .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def; Combines RDA dedicatee (work) and dedicatee of item (item)"@en .
+_:nb0d5787c23ba479dbc3e53e326ec3953b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Dedicatee of item" .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#code> "dte" .
+<http://id.loc.gov/vocabulary/relators/dte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/dte
+
+# BEGIN /vocabulary/relators/dtm
+
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Data manager" .
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.loc.gov/mads/rdf/v1#code> "dtm" .
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dtm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for managing databases or other data sources"@en .
+
+# END /vocabulary/relators/dtm
+
+# BEGIN /vocabulary/relators/dto
+
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who writes a dedication, which may be a formal statement or in epistolary or verse form"@en .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Dedicator" .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#code> "dto" .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/dto> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/dto
+
+# BEGIN /vocabulary/relators/dub
+
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.loc.gov/mads/rdf/v1#code> "dub" .
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Dubious author" .
+<http://id.loc.gov/vocabulary/relators/dub> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization to which authorship has been dubiously or incorrectly ascribed"@en .
+
+# END /vocabulary/relators/dub
+
+# BEGIN /vocabulary/relators/edc
+
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#code> "edc" .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Editor of compilation" .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler"@en .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/edc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/edc
+
+# BEGIN /vocabulary/relators/edm
+
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n7b69219aaddc405098a90cd952fc60bfb1 .
+_:n7b69219aaddc405098a90cd952fc60bfb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Moving image work editor" .
+_:n7b69219aaddc405098a90cd952fc60bfb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/flm> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for assembling, arranging, and trimming film, video, or other moving image formats, including both visual and audio aspects"@en .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film editor" .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#code> "edm" .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Editor of moving image work" .
+
+# END /vocabulary/relators/edm
+
+# BEGIN /vocabulary/relators/edt
+
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#code> "edt" .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Editor" .
+<http://id.loc.gov/vocabulary/relators/edt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author"@en .
+
+# END /vocabulary/relators/edt
+
+# BEGIN /vocabulary/relators/egr
+
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who cuts letters, figures, etc. on a surface, such as a wooden or metal plate used for printing"@en .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Metal-engraver" .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/mte> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Engraver" .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#code> "egr" .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/egr
+
+# BEGIN /vocabulary/relators/elg
+
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Electrician" .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n4eaad43e00ab49eeb95eb1e52ce24f94b1 .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#code> "elg" .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person responsible for setting up a lighting rig and focusing the lights for a production, and running the lighting at a performance"@en .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n4eaad43e00ab49eeb95eb1e52ce24f94b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:n4eaad43e00ab49eeb95eb1e52ce24f94b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:n4eaad43e00ab49eeb95eb1e52ce24f94b2 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Master electrician" .
+_:n4eaad43e00ab49eeb95eb1e52ce24f94b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Chief electrician" .
+_:n4eaad43e00ab49eeb95eb1e52ce24f94b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:n4eaad43e00ab49eeb95eb1e52ce24f94b3 <http://www.loc.gov/mads/rdf/v1#variantLabel> "House electrician" .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n4eaad43e00ab49eeb95eb1e52ce24f94b3 .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n4eaad43e00ab49eeb95eb1e52ce24f94b2 .
+<http://id.loc.gov/vocabulary/relators/elg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/elg
+
+# BEGIN /vocabulary/relators/elt
+
+<http://id.loc.gov/vocabulary/relators/elt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/elt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/elt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Electrotyper" .
+<http://id.loc.gov/vocabulary/relators/elt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/elt> <http://www.loc.gov/mads/rdf/v1#code> "elt" .
+<http://id.loc.gov/vocabulary/relators/elt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who creates a duplicate printing surface by pressure molding and electrodepositing of metal that is then backed up with lead for printing"@en .
+
+# END /vocabulary/relators/elt
+
+# BEGIN /vocabulary/relators/eng
+
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.loc.gov/mads/rdf/v1#code> "eng" .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that is responsible for technical planning and design, particularly with construction"@en .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Engineer" .
+<http://id.loc.gov/vocabulary/relators/eng> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/eng
+
+# BEGIN /vocabulary/relators/enj
+
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A jurisdiction enacting a law, regulation, constitution, court rule, etc."@en .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#code> "enj" .
+<http://id.loc.gov/vocabulary/relators/enj> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Enacting jurisdiction" .
+
+# END /vocabulary/relators/enj
+
+# BEGIN /vocabulary/relators/etr
+
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who produces text or images for printing by subjecting metal, glass, or some other surface to acid or the corrosive action of some other substance"@en .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#code> "etr" .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Etcher" .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/etr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/etr
+
+# BEGIN /vocabulary/relators/evp
+
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A place where an event such as a conference or a concert took place"@en .
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Event place" .
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.loc.gov/mads/rdf/v1#code> "evp" .
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/evp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/evp
+
+# BEGIN /vocabulary/relators/exp
+
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization in charge of the description and appraisal of the value of goods, particularly rare items, works of art, etc."@en .
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+_:nc5a68d239d30478a9a29bd56a70e1dd7b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Appraiser" .
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Expert" .
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nc5a68d239d30478a9a29bd56a70e1dd7b1 .
+<http://id.loc.gov/vocabulary/relators/exp> <http://www.loc.gov/mads/rdf/v1#code> "exp" .
+_:nc5a68d239d30478a9a29bd56a70e1dd7b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+
+# END /vocabulary/relators/exp
+
+# BEGIN /vocabulary/relators/fac
+
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n8488cc72724041ada71e9af596a118d8b1 .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Facsimilist" .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.loc.gov/mads/rdf/v1#code> "fac" .
+_:n8488cc72724041ada71e9af596a118d8b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Copier" .
+_:n8488cc72724041ada71e9af596a118d8b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fac> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that executed the facsimile"@en .
+
+# END /vocabulary/relators/fac
+
+# BEGIN /vocabulary/relators/fds
+
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/dst> .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film distributor" .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDADistributor> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Distributor" .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#code> "fds" .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in distributing a moving image resource to theatres or other distribution channels"@en .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/fds> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/fds
+
+# BEGIN /vocabulary/relators/fld
+
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.loc.gov/mads/rdf/v1#code> "fld" .
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that manages or supervises the work done to collect raw data or do research in an actual setting or environment (typically applies to the natural and social sciences)"@en .
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/fld> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Field director" .
+
+# END /vocabulary/relators/fld
+
+# BEGIN /vocabulary/relators/flm
+
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/edm> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who, following the script and in creative cooperation with the Director, selects, arranges, and assembles the filmed material, controls the synchronization of picture and sound, and participates in other post-production tasks such as sound mixing and visual effects processing. Today, picture editing is often performed digitally."@en .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#sourceNote> "FIAF"@en .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def (FIAF)"@en .
+_:nca6887395a0e45fc840b882ac9f10c6ab1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+_:nca6887395a0e45fc840b882ac9f10c6ab1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Motion picture editor" .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nca6887395a0e45fc840b882ac9f10c6ab1 .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film editor" .
+<http://id.loc.gov/vocabulary/relators/flm> <http://www.loc.gov/mads/rdf/v1#code> "flm" .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/edm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Editor of moving image work" .
+
+# END /vocabulary/relators/flm
+
+# BEGIN /vocabulary/relators/fmd
+
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Director" .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#code> "fmd" .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film director" .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/drt> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A director responsible for the general management and supervision of a filmed performance"@en .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/fmd
+
+# BEGIN /vocabulary/relators/fmk
+
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Director" .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Filmmaker" .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family or organization responsible for creating an independent or personal film. A filmmaker is individually responsible for the conception and execution of all aspects of the film"@en .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#code> "fmk" .
+<http://id.loc.gov/vocabulary/relators/fmk> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/drt> .
+
+# END /vocabulary/relators/fmk
+
+# BEGIN /vocabulary/relators/fmo
+
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Donor" .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/sll> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/dnr> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOwner> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Former owner" .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def; in RDA associated with Owner (element) which is broader than MARC owner (which means current owner)"@en .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#code> "fmo" .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Seller" .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization formerly having legal possession of an item"@en .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/dnr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/fmo
+
+# BEGIN /vocabulary/relators/fmp
+
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film producer" .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Producer" .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/pro> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#code> "fmp" .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A producer responsible for most of the business aspects of a film"@en .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/fmp
+
+# BEGIN /vocabulary/relators/fnd
+
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Funder" .
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that furnished financial support for the production of the work"@en .
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fnd> <http://www.loc.gov/mads/rdf/v1#code> "fnd" .
+
+# END /vocabulary/relators/fnd
+
+# BEGIN /vocabulary/relators/fpy
+
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is identified as the only party or the party of the first party. In the case of transfer of rights, this is the assignor, transferor, licensor, grantor, etc. Multiple parties can be named jointly as the first party"@en .
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.loc.gov/mads/rdf/v1#code> "fpy" .
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "First party" .
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/fpy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/fpy
+
+# BEGIN /vocabulary/relators/frg
+
+_:nc1dd8515887a43adba8af8bbc18d7227b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:nc1dd8515887a43adba8af8bbc18d7227b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Counterfeiter" .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nc1dd8515887a43adba8af8bbc18d7227b2 .
+_:nc1dd8515887a43adba8af8bbc18d7227b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:nc1dd8515887a43adba8af8bbc18d7227b2 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Copier" .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Forger" .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nc1dd8515887a43adba8af8bbc18d7227b1 .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#code> "frg" .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who makes or imitates something of value or importance, especially with the intent to defraud"@en .
+<http://id.loc.gov/vocabulary/relators/frg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/frg
+
+# BEGIN /vocabulary/relators/gis
+
+_:nf523041b53664641bd6962abed3770efb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#code> "gis" .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person responsible for geographic information system (GIS) development and integration with global positioning system data"@en .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Geographic information specialist" .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nf523041b53664641bd6962abed3770efb1 .
+<http://id.loc.gov/vocabulary/relators/gis> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+_:nf523041b53664641bd6962abed3770efb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Geospatial information specialist" .
+
+# END /vocabulary/relators/gis
+
+# BEGIN /vocabulary/relators/grt
+
+<http://id.loc.gov/vocabulary/relators/grt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/grt> <http://www.loc.gov/mads/rdf/v1#code> "grt" .
+<http://id.loc.gov/vocabulary/relators/grt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority> .
+_:ned7da218c24c4bb69f935d5ded1dba81b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Artist" .
+<http://id.loc.gov/vocabulary/relators/grt> <http://www.loc.gov/mads/rdf/v1#deprecatedLabel> "Graphic technician" .
+<http://id.loc.gov/vocabulary/relators/grt> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:ned7da218c24c4bb69f935d5ded1dba81b1 .
+_:ned7da218c24c4bb69f935d5ded1dba81b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/grt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/grt
+
+# BEGIN /vocabulary/relators/his
+
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/hst> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Host" .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#code> "his" .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource"@en .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Host institution" .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/his
+
+# BEGIN /vocabulary/relators/hnr
+
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def; combines RDA honoree and honoree of item"@en .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#code> "hnr" .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"@en .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nb2a1a2df599b48ee988801b5ad441143b2 .
+_:nb2a1a2df599b48ee988801b5ad441143b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Honouree" .
+_:nb2a1a2df599b48ee988801b5ad441143b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Honoree" .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+_:nb2a1a2df599b48ee988801b5ad441143b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:nb2a1a2df599b48ee988801b5ad441143b2 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Honouree of item" .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nb2a1a2df599b48ee988801b5ad441143b1 .
+<http://id.loc.gov/vocabulary/relators/hnr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/hnr
+
+# BEGIN /vocabulary/relators/hst
+
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#code> "hst" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Host" .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Host institution" .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/his> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/his> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by leading a program (often broadcast) that includes other guests, performers, etc. (e.g., talk show host)"@en .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/hst
+
+# BEGIN /vocabulary/relators/ill
+
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by supplementing the primary content with drawings, diagrams, photographs, etc. If the work is primarily the artistic content created by this entity, use artist or photographer"@en .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Illustrator" .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#code> "ill" .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ill> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/ill
+
+# BEGIN /vocabulary/relators/ilu
+
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#code> "ilu" .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person providing decoration to a specific item using precious metals or color, often with elaborate designs and motifs"@en .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ilu> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Illuminator" .
+
+# END /vocabulary/relators/ilu
+
+# BEGIN /vocabulary/relators/ins
+
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who has written a statement of dedication or gift"@en .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Inscriber" .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ins> <http://www.loc.gov/mads/rdf/v1#code> "ins" .
+
+# END /vocabulary/relators/ins
+
+# BEGIN /vocabulary/relators/inv
+
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Inventor" .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n797678ab0a1b4507b40a8de2149d9d97b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Patent inventor" .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n797678ab0a1b4507b40a8de2149d9d97b1 .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#code> "inv" .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a new device or process"@en .
+<http://id.loc.gov/vocabulary/relators/inv> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+_:n797678ab0a1b4507b40a8de2149d9d97b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+
+# END /vocabulary/relators/inv
+
+# BEGIN /vocabulary/relators/isb
+
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#code> "isb" .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family or organization issuing a work, such as an official organ of the body"@en .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Issuing body" .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/isb
+
+# BEGIN /vocabulary/relators/itr
+
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by playing a musical instrument"@en .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#code> "itr" .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Instrumentalist" .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+
+# END /vocabulary/relators/itr
+
+# BEGIN /vocabulary/relators/ive
+
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#code> "ive" .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Interviewee" .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family or organization responsible for creating or contributing to a resource by responding to an interviewer, usually a reporter, pollster, or some other information gathering agent"@en .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ive> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/ive
+
+# BEGIN /vocabulary/relators/ivr
+
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Interviewer" .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#code> "ivr" .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating or contributing to a resource by acting as an interviewer, reporter, pollster, or some other information gathering agent"@en .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ivr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/ivr
+
+# BEGIN /vocabulary/relators/jud
+
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who hears and decides on legal matters in court."@en .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Judge" .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.loc.gov/mads/rdf/v1#code> "jud" .
+<http://id.loc.gov/vocabulary/relators/jud> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/jud
+
+# BEGIN /vocabulary/relators/jug
+
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A jurisdiction governed by a law, regulation, etc., that was enacted by another jurisdiction"@en .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#code> "jug" .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Jurisdiction governed" .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/jug> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+
+# END /vocabulary/relators/jug
+
+# BEGIN /vocabulary/relators/lbr
+
+<http://id.loc.gov/vocabulary/relators/lbr> <http://www.loc.gov/mads/rdf/v1#code> "lbr" .
+<http://id.loc.gov/vocabulary/relators/lbr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lbr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Laboratory" .
+<http://id.loc.gov/vocabulary/relators/lbr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An organization that provides scientific analyses of material samples"@en .
+<http://id.loc.gov/vocabulary/relators/lbr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lbr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/lbr
+
+# BEGIN /vocabulary/relators/lbt
+
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Librettist" .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An author of a libretto of an opera or other stage work, or an oratorio"@en .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#code> "lbt" .
+<http://id.loc.gov/vocabulary/relators/lbt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+
+# END /vocabulary/relators/lbt
+
+# BEGIN /vocabulary/relators/ldr
+
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.loc.gov/mads/rdf/v1#code> "ldr" .
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Laboratory director" .
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n74507036b88047b3ab70a94dffb0834db1 .
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n74507036b88047b3ab70a94dffb0834db1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Lab director" .
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ldr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that manages or supervises work done in a controlled setting or environment"@en .
+_:n74507036b88047b3ab70a94dffb0834db1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+
+# END /vocabulary/relators/ldr
+
+# BEGIN /vocabulary/relators/led
+
+<http://id.loc.gov/vocabulary/relators/led> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/led> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/led> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/led> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/led> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Lead" .
+<http://id.loc.gov/vocabulary/relators/led> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that takes primary responsibility for a particular activity or endeavor. May be combined with another relator term or code to show the greater importance this person or organization has regarding that particular role. If more than one relator is assigned to a heading, use the Lead relator only if it applies to all the relators"@en .
+<http://id.loc.gov/vocabulary/relators/led> <http://www.loc.gov/mads/rdf/v1#code> "led" .
+
+# END /vocabulary/relators/led
+
+# BEGIN /vocabulary/relators/lee
+
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A libelee against whom an appeal is taken from one ecclesiastical court or admiralty to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#code> "lee" .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://id.loc.gov/vocabulary/relators/lei> .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/lei> .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lee> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelee-appellee" .
+
+# END /vocabulary/relators/lee
+
+# BEGIN /vocabulary/relators/lel
+
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelee-appellant" .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/let> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelee" .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization against whom a libel has been filed in an ecclesiastical court or admiralty"@en .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#code> "lel" .
+
+# END /vocabulary/relators/lel
+
+# BEGIN /vocabulary/relators/len
+
+<http://id.loc.gov/vocabulary/relators/len> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/len> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/len> <http://www.loc.gov/mads/rdf/v1#code> "len" .
+<http://id.loc.gov/vocabulary/relators/len> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Lender" .
+<http://id.loc.gov/vocabulary/relators/len> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/len> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization permitting the temporary use of a book, manuscript, etc., such as for photocopying or microfilming"@en .
+
+# END /vocabulary/relators/len
+
+# BEGIN /vocabulary/relators/let
+
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A libelee who takes an appeal from one ecclesiastical court or admiralty to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelee-appellant" .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#code> "let" .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelee" .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/lel> .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/let> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/let
+
+# BEGIN /vocabulary/relators/lgd
+
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.loc.gov/mads/rdf/v1#code> "lgd" .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who designs the lighting scheme for a theatrical presentation, entertainment, motion picture, etc."@en .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Lighting designer" .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lgd> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/lgd
+
+# BEGIN /vocabulary/relators/lie
+
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant-appellee" .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant" .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/lil> .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A libelant against whom an appeal is taken from one ecclesiastical court or admiralty to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#code> "lie" .
+
+# END /vocabulary/relators/lie
+
+# BEGIN /vocabulary/relators/lil
+
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant-appellant" .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lie> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant-appellee" .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/lit> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who files a libel in an ecclesiastical or admiralty case"@en .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/lie> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#code> "lil" .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant" .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/lil
+
+# BEGIN /vocabulary/relators/lit
+
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant-appellant" .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/lil> .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A libelant who takes an appeal from one ecclesiastical court or admiralty to another to reverse the judgment"@en .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lil> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Libelant" .
+<http://id.loc.gov/vocabulary/relators/lit> <http://www.loc.gov/mads/rdf/v1#code> "lit" .
+
+# END /vocabulary/relators/lit
+
+# BEGIN /vocabulary/relators/lsa
+
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Architect" .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Landscape architect" .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/arc> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#code> "lsa" .
+<http://id.loc.gov/vocabulary/relators/arc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lsa> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An architect responsible for creating landscape works. This work involves coordinating the arrangement of existing and proposed land features and structures"@en .
+
+# END /vocabulary/relators/lsa
+
+# BEGIN /vocabulary/relators/lse
+
+<http://id.loc.gov/vocabulary/relators/lse> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lse> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lse> <http://www.loc.gov/mads/rdf/v1#code> "lse" .
+<http://id.loc.gov/vocabulary/relators/lse> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lse> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is an original recipient of the right to print or publish"@en .
+<http://id.loc.gov/vocabulary/relators/lse> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Licensee" .
+
+# END /vocabulary/relators/lse
+
+# BEGIN /vocabulary/relators/lso
+
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.loc.gov/mads/rdf/v1#code> "lso" .
+_:n9df817cfa3594005b0d48633074a61eeb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Imprimatur" .
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n9df817cfa3594005b0d48633074a61eeb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n9df817cfa3594005b0d48633074a61eeb1 .
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is a signer of the license, imprimatur, etc"@en .
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lso> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Licensor" .
+
+# END /vocabulary/relators/lso
+
+# BEGIN /vocabulary/relators/ltg
+
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who prepares the stone or plate for lithographic printing, including a graphic artist creating a design directly on the surface from which printing will be done."@en .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#code> "ltg" .
+<http://id.loc.gov/vocabulary/relators/ltg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Lithographer" .
+
+# END /vocabulary/relators/ltg
+
+# BEGIN /vocabulary/relators/lyr
+
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#code> "lyr" .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An author of the words of a non-dramatic musical work (e.g. the text of a song), except for oratorios"@en .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Lyricist" .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/aut> .
+<http://id.loc.gov/vocabulary/relators/aut> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Author" .
+<http://id.loc.gov/vocabulary/relators/lyr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/lyr
+
+# BEGIN /vocabulary/relators/mcp
+
+<http://id.loc.gov/vocabulary/relators/mcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mcp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Music copyist" .
+<http://id.loc.gov/vocabulary/relators/mcp> <http://www.loc.gov/mads/rdf/v1#code> "mcp" .
+<http://id.loc.gov/vocabulary/relators/mcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mcp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who transcribes or copies musical notation"@en .
+<http://id.loc.gov/vocabulary/relators/mcp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/mcp
+
+# BEGIN /vocabulary/relators/mdc
+
+<http://id.loc.gov/vocabulary/relators/mdc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mdc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Metadata contact" .
+<http://id.loc.gov/vocabulary/relators/mdc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization primarily responsible for compiling and maintaining the original description of a metadata set (e.g., geospatial metadata set)"@en .
+<http://id.loc.gov/vocabulary/relators/mdc> <http://www.loc.gov/mads/rdf/v1#code> "mdc" .
+<http://id.loc.gov/vocabulary/relators/mdc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mdc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/mdc
+
+# BEGIN /vocabulary/relators/med
+
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Medium" .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#code> "med" .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/med> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person held to be a channel of communication between the earthly world and a world"@en .
+
+# END /vocabulary/relators/med
+
+# BEGIN /vocabulary/relators/mfp
+
+<http://id.loc.gov/vocabulary/relators/mfp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mfp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "The place of manufacture (e.g., printing, duplicating, casting, etc.) of a resource in a published form"@en .
+<http://id.loc.gov/vocabulary/relators/mfp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Manufacture place" .
+<http://id.loc.gov/vocabulary/relators/mfp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mfp> <http://www.loc.gov/mads/rdf/v1#code> "mfp" .
+<http://id.loc.gov/vocabulary/relators/mfp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/mfp
+
+# BEGIN /vocabulary/relators/mfr
+
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for printing, duplicating, casting, etc. a resource"@en .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Manufacturer" .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prv> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Provider" .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#code> "mfr" .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/mfr
+
+# BEGIN /vocabulary/relators/mod
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by leading a program (often broadcast) where topics are discussed, usually with participation of experts in fields related to the discussion"@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Moderator" .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#code> "mod" .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/mod
+
+# BEGIN /vocabulary/relators/mon
+
+<http://id.loc.gov/vocabulary/relators/mon> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mon> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mon> <http://www.loc.gov/mads/rdf/v1#code> "mon" .
+<http://id.loc.gov/vocabulary/relators/mon> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that supervises compliance with the contract and is responsible for the report and controls its distribution. Sometimes referred to as the grantee, or controlling agency"@en .
+<http://id.loc.gov/vocabulary/relators/mon> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Monitor" .
+<http://id.loc.gov/vocabulary/relators/mon> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/mon
+
+# BEGIN /vocabulary/relators/mrb
+
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.loc.gov/mads/rdf/v1#definitionNote> "The entity responsible for marbling paper, cloth, leather, etc. used in construction of a resource"@en .
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.loc.gov/mads/rdf/v1#code> "mrb" .
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Marbler" .
+<http://id.loc.gov/vocabulary/relators/mrb> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/mrb
+
+# BEGIN /vocabulary/relators/mrk
+
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization performing the coding of SGML, HTML, or XML markup of metadata, text, etc."@en .
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.loc.gov/mads/rdf/v1#code> "mrk" .
+_:neb90a63f78744ea99a1144fb74114ef5b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:neb90a63f78744ea99a1144fb74114ef5b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Encoder" .
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:neb90a63f78744ea99a1144fb74114ef5b1 .
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mrk> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Markup editor" .
+
+# END /vocabulary/relators/mrk
+
+# BEGIN /vocabulary/relators/msd
+
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who coordinates the activities of the composer, the sound editor, and sound mixers for a moving image production or for a musical or dramatic presentation or entertainment"@en .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#code> "msd" .
+<http://id.loc.gov/vocabulary/relators/msd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Musical director" .
+
+# END /vocabulary/relators/msd
+
+# BEGIN /vocabulary/relators/mte
+
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An engraver responsible for decorations, illustrations, letters, etc. cut on a metal surface for printing or decoration"@en .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Metal-engraver" .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/egr> .
+<http://id.loc.gov/vocabulary/relators/egr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Engraver" .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#code> "mte" .
+<http://id.loc.gov/vocabulary/relators/mte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/mte
+
+# BEGIN /vocabulary/relators/mtk
+
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Minute taker" .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#code> "mtk" .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for recording the minutes of a meeting"@en .
+<http://id.loc.gov/vocabulary/relators/mtk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+
+# END /vocabulary/relators/mtk
+
+# BEGIN /vocabulary/relators/mus
+
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.loc.gov/mads/rdf/v1#code> "mus" .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who performs music or contributes to the musical content of a work when it is not possible or desirable to identify the function more precisely"@en .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Musician" .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/mus> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/mus
+
+# BEGIN /vocabulary/relators/nrt
+
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by reading or speaking in order to give an account of an act, occurrence, course of events, etc"@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Narrator" .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#code> "nrt" .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/nrt
+
+# BEGIN /vocabulary/relators/opn
+
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.loc.gov/mads/rdf/v1#code> "opn" .
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Opponent" .
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for opposing a thesis or dissertation"@en .
+<http://id.loc.gov/vocabulary/relators/opn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/opn
+
+# BEGIN /vocabulary/relators/org
+
+<http://id.loc.gov/vocabulary/relators/org> <http://www.loc.gov/mads/rdf/v1#code> "org" .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Originator" .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization performing the work, i.e., the name of a person or organization associated with the intellectual content of the work. This category does not include the publisher or personal affiliation, or sponsor except where it is also the corporate author"@en .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/org> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/org
+
+# BEGIN /vocabulary/relators/orm
+
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#code> "orm" .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource"@en .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n2efcc2a3f1cf4f55a30287c5ae9ead7bb1 .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Organizer" .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n2efcc2a3f1cf4f55a30287c5ae9ead7bb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:n2efcc2a3f1cf4f55a30287c5ae9ead7bb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Organizer of meeting" .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC term and def"@en .
+<http://id.loc.gov/vocabulary/relators/orm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/orm
+
+# BEGIN /vocabulary/relators/osp
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#code> "osp" .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to an expression of a work by appearing on screen in nonfiction moving image materials or introductions to fiction moving image materials to provide contextual or background information. Use when another term (e.g., narrator, host) is either not applicable or not desired"@en .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Onscreen presenter" .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/osp
+
+# BEGIN /vocabulary/relators/oth
+
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#code> "oth" .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Other" .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/oth> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A role that has no equivalent in the MARC list."@en .
+
+# END /vocabulary/relators/oth
+
+# BEGIN /vocabulary/relators/own
+
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n122a42cd9de84544a426e91c29d8f4bdb1 .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Owner" .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/dpt> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+_:n122a42cd9de84544a426e91c29d8f4bdb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#code> "own" .
+_:n122a42cd9de84544a426e91c29d8f4bdb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Current owner" .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Combined defs"@en .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOwner> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/dpt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Depositor" .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/own> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization that currently owns an item or collection, i.e.has legal possession of a resource"@en .
+
+# END /vocabulary/relators/own
+
+# BEGIN /vocabulary/relators/pan
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Panelist" .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by participating in a program (often broadcast) where topics are discussed, usually with participation of experts in fields related to the discussion"@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#code> "pan" .
+
+# END /vocabulary/relators/pan
+
+# BEGIN /vocabulary/relators/pat
+
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.loc.gov/mads/rdf/v1#code> "pat" .
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Patron" .
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for commissioning a work. Usually a patron uses his or her means or influence to support the work of artists, writers, etc. This includes those who commission and pay for individual works"@en .
+<http://id.loc.gov/vocabulary/relators/pat> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/pat
+
+# BEGIN /vocabulary/relators/pbd
+
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who presides over the elaboration of a collective work to ensure its coherence or continuity. This includes editors-in-chief, literary editors, editors of series, etc."@en .
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.loc.gov/mads/rdf/v1#code> "pbd" .
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Publishing director" .
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pbd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/pbd
+
+# BEGIN /vocabulary/relators/pbl
+
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#code> "pbl" .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/publisher> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Provider" .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prv> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Publisher" .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for publishing, releasing, or issuing a resource"@en .
+
+# END /vocabulary/relators/pbl
+
+# BEGIN /vocabulary/relators/pdr
+
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.loc.gov/mads/rdf/v1#code> "pdr" .
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization with primary responsibility for all essential aspects of a project, has overall responsibility for managing projects, or provides overall direction to a project manager"@en .
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Project director" .
+<http://id.loc.gov/vocabulary/relators/pdr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/pdr
+
+# BEGIN /vocabulary/relators/pfr
+
+<http://id.loc.gov/vocabulary/relators/pfr> <http://www.loc.gov/mads/rdf/v1#code> "pfr" .
+<http://id.loc.gov/vocabulary/relators/pfr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Proofreader" .
+<http://id.loc.gov/vocabulary/relators/pfr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pfr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pfr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who corrects printed matter. For manuscripts, use Corrector [crr]"@en .
+<http://id.loc.gov/vocabulary/relators/pfr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/pfr
+
+# BEGIN /vocabulary/relators/pht
+
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Photographer" .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#code> "pht" .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a photographic work"@en .
+<http://id.loc.gov/vocabulary/relators/pht> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/pht
+
+# BEGIN /vocabulary/relators/plt
+
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in manufacturing a manifestation by preparing plates used in the production of printed images and/or text"@en .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#code> "plt" .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Platemaker" .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/plt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/plt
+
+# BEGIN /vocabulary/relators/pma
+
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Permitting agency" .
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An organization (usually a government agency) that issues permits under which work is accomplished"@en .
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.loc.gov/mads/rdf/v1#code> "pma" .
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pma> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/pma
+
+# BEGIN /vocabulary/relators/pmn
+
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person responsible for all technical and business matters in a production"@en .
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.loc.gov/mads/rdf/v1#code> "pmn" .
+<http://id.loc.gov/vocabulary/relators/pmn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Production manager" .
+
+# END /vocabulary/relators/pmn
+
+# BEGIN /vocabulary/relators/pop
+
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Printer of plates" .
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n5f32cf4f4b1e4b988e8dbe3055c0a253b1 .
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who prints illustrations from plates."@en .
+_:n5f32cf4f4b1e4b988e8dbe3055c0a253b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:n5f32cf4f4b1e4b988e8dbe3055c0a253b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Plates, printer of" .
+<http://id.loc.gov/vocabulary/relators/pop> <http://www.loc.gov/mads/rdf/v1#code> "pop" .
+
+# END /vocabulary/relators/pop
+
+# BEGIN /vocabulary/relators/ppm
+
+<http://id.loc.gov/vocabulary/relators/ppm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the production of paper, usually from wood, cloth, or other fibrous material"@en .
+<http://id.loc.gov/vocabulary/relators/ppm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ppm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ppm> <http://www.loc.gov/mads/rdf/v1#code> "ppm" .
+<http://id.loc.gov/vocabulary/relators/ppm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Papermaker" .
+<http://id.loc.gov/vocabulary/relators/ppm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/ppm
+
+# BEGIN /vocabulary/relators/ppt
+
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by manipulating, controlling, or directing puppets or marionettes in a moving image production or a musical or dramatic presentation or entertainment"@en .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#code> "ppt" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Puppeteer" .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/ppt
+
+# BEGIN /vocabulary/relators/pra
+
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation"@en .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#code> "pra" .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Praeses" .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/pra> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/pra
+
+# BEGIN /vocabulary/relators/prc
+
+<http://id.loc.gov/vocabulary/relators/prc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prc> <http://www.loc.gov/mads/rdf/v1#code> "prc" .
+<http://id.loc.gov/vocabulary/relators/prc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization primarily responsible for performing or initiating a process, such as is done with the collection of metadata sets"@en .
+<http://id.loc.gov/vocabulary/relators/prc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Process contact" .
+
+# END /vocabulary/relators/prc
+
+# BEGIN /vocabulary/relators/prd
+
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Production personnel" .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization associated with the production (props, lighting, special effects, etc.) of a musical or dramatic presentation or entertainment"@en .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.loc.gov/mads/rdf/v1#code> "prd" .
+<http://id.loc.gov/vocabulary/relators/prd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/prd
+
+# BEGIN /vocabulary/relators/pre
+
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#editorialNote> "includes one sentence from FIAF def"@en .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Presenter" .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization mentioned in an “X presents” credit for moving image materials and who is associated with production, finance, or distribution in some way. A vanity credit; in early years, normally the head of a studio"@en .
+<http://id.loc.gov/vocabulary/relators/pre> <http://www.loc.gov/mads/rdf/v1#code> "pre" .
+
+# END /vocabulary/relators/pre
+
+# BEGIN /vocabulary/relators/prf
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/act> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#code> "prf" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/dnc> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Host" .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/mod> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person contributing to a resource by performing music, acting, dancing, speaking, etc., often in a musical or dramatic presentation, etc. If specific codes are used, [prf] is used for a person whose principal skill is not known or specified"@en .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/itr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Instrumentalist" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cmm> .
+<http://id.loc.gov/vocabulary/relators/hst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/pan> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Panelist" .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Singer" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Puppeteer" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/sng> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Storyteller" .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cmm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Commentator" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/cnd> .
+<http://id.loc.gov/vocabulary/relators/ppt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mod> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Moderator" .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Dancer" .
+<http://id.loc.gov/vocabulary/relators/nrt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Narrator" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pan> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dnc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/hst> .
+<http://id.loc.gov/vocabulary/relators/osp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Onscreen presenter" .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Speaker" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/stl> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/cnd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Conductor" .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Actor" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/ppt> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/nrt> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/tch> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Teacher" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/spk> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/itr> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/osp> .
+
+# END /vocabulary/relators/prf
+
+# BEGIN /vocabulary/relators/prg
+
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#code> "prg" .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for creating a computer program"@en .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Programmer" .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/prg> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/prg
+
+# BEGIN /vocabulary/relators/prm
+
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Printmaker" .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who makes a relief, intaglio, or planographic printing surface"@en .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#code> "prm" .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/prm
+
+# BEGIN /vocabulary/relators/prn
+
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#code> "prn" .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Production company" .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An organization that is responsible for financial, technical, and organizational management of a production for stage, screen, audio recording, television, webcast, etc."@en .
+<http://id.loc.gov/vocabulary/relators/prn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/prn
+
+# BEGIN /vocabulary/relators/pro
+
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prv> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/rpc> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Provider" .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/fmp> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/tlp> .
+<http://id.loc.gov/vocabulary/relators/fmp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Film producer" .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Producer" .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#code> "pro" .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Television producer" .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for most of the business aspects of a production for screen, audio recording, television, webcast, etc. The producer is generally responsible for fund raising, managing the production, hiring key personnel, arranging for distributors, etc."@en .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Radio producer" .
+
+# END /vocabulary/relators/pro
+
+# BEGIN /vocabulary/relators/prp
+
+<http://id.loc.gov/vocabulary/relators/prp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Production place" .
+<http://id.loc.gov/vocabulary/relators/prp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "The place of production (e.g., inscription, fabrication, construction, etc.) of a resource in an unpublished form"@en .
+<http://id.loc.gov/vocabulary/relators/prp> <http://www.loc.gov/mads/rdf/v1#code> "prp" .
+
+# END /vocabulary/relators/prp
+
+# BEGIN /vocabulary/relators/prs
+
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Production designer" .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for designing the overall visual appearance of a moving image production"@en .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#code> "prs" .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/prs> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/prs
+
+# BEGIN /vocabulary/relators/prt
+
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManifestation> .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAManufacturer> .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Printer" .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#code> "prt" .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/prt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization involved in manufacturing a manifestation of printed text, notated music, etc., from type or plates, such as a book, newspaper, magazine, broadside, score, etc"@en .
+
+# END /vocabulary/relators/prt
+
+# BEGIN /vocabulary/relators/prv
+
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/mfr> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#code> "prv" .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/dst> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Manufacturer" .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/pbl> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/pro> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Provider" .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Producer" .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who produces, publishes, manufactures, or distributes a resource if specific codes are not desired (e.g. [mfr], [pbl])"@en .
+<http://id.loc.gov/vocabulary/relators/dst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Distributor" .
+<http://id.loc.gov/vocabulary/relators/prv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Publisher" .
+<http://id.loc.gov/vocabulary/relators/pbl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/mfr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/prv
+
+# BEGIN /vocabulary/relators/pta
+
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.loc.gov/mads/rdf/v1#code> "pta" .
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Patent applicant" .
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that applied for a patent"@en .
+<http://id.loc.gov/vocabulary/relators/pta> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/pta
+
+# BEGIN /vocabulary/relators/pte
+
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/ptf> .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff-appellee" .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff" .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#code> "pte" .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A plaintiff against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in a legal proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/pte
+
+# BEGIN /vocabulary/relators/ptf
+
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/ptt> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff" .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/pte> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff-appellee" .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/pte> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who brings a suit in a civil proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#code> "ptf" .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff-appellant" .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/ptf
+
+# BEGIN /vocabulary/relators/pth
+
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:nb59e351b9af04c7cb00a6809d5d9a4deb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Patentee" .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that was granted the patent referred to by the item"@en .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#code> "pth" .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nb59e351b9af04c7cb00a6809d5d9a4deb1 .
+<http://id.loc.gov/vocabulary/relators/pth> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Patent holder" .
+_:nb59e351b9af04c7cb00a6809d5d9a4deb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+
+# END /vocabulary/relators/pth
+
+# BEGIN /vocabulary/relators/ptt
+
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A plaintiff who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in a legal proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff-appellant" .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/ptf> .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ptf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Plaintiff" .
+<http://id.loc.gov/vocabulary/relators/ptt> <http://www.loc.gov/mads/rdf/v1#code> "ptt" .
+
+# END /vocabulary/relators/ptt
+
+# BEGIN /vocabulary/relators/pup
+
+<http://id.loc.gov/vocabulary/relators/pup> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/pup> <http://www.loc.gov/mads/rdf/v1#code> "pup" .
+<http://id.loc.gov/vocabulary/relators/pup> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/pup> <http://www.loc.gov/mads/rdf/v1#definitionNote> "The place where a resource is published"@en .
+<http://id.loc.gov/vocabulary/relators/pup> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Publication place" .
+<http://id.loc.gov/vocabulary/relators/pup> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/pup
+
+# BEGIN /vocabulary/relators/rbr
+
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for parts of a work, often headings or opening parts of a manuscript, that appear in a distinctive color, usually red"@en .
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Rubricator" .
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.loc.gov/mads/rdf/v1#code> "rbr" .
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rbr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/rbr
+
+# BEGIN /vocabulary/relators/rcd
+
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#code> "rcd" .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Recordist" .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rcd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who uses a recording device to capture sounds and/or video during a recording session, including field recordings of natural sounds, folkloric events, music, etc."@en .
+
+# END /vocabulary/relators/rcd
+
+# BEGIN /vocabulary/relators/rce
+
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#code> "rce" .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person contributing to a resource by supervising the technical aspects of a sound or video recording session"@en .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rce> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Recording engineer" .
+
+# END /vocabulary/relators/rce
+
+# BEGIN /vocabulary/relators/rcp
+
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization to whom the correspondence in a work is addressed"@en .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+_:ne5c64efaf594414fa56f735c9d131decb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Recipient" .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#editorialNote> "changed MARC term and def"@en .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:ne5c64efaf594414fa56f735c9d131decb1 .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Addressee" .
+<http://id.loc.gov/vocabulary/relators/rcp> <http://www.loc.gov/mads/rdf/v1#code> "rcp" .
+_:ne5c64efaf594414fa56f735c9d131decb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+
+# END /vocabulary/relators/rcp
+
+# BEGIN /vocabulary/relators/rdd
+
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#code> "rdd" .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A director responsible for the general management and supervision of a radio program"@en .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Director" .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/drt> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Radio director" .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rdd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/rdd
+
+# BEGIN /vocabulary/relators/red
+
+<http://id.loc.gov/vocabulary/relators/red> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Redaktor" .
+<http://id.loc.gov/vocabulary/relators/red> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/red> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/red> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who writes or develops the framework for an item without being intellectually responsible for its content"@en .
+<http://id.loc.gov/vocabulary/relators/red> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/red> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/red> <http://www.loc.gov/mads/rdf/v1#code> "red" .
+
+# END /vocabulary/relators/red
+
+# BEGIN /vocabulary/relators/ren
+
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Renderer" .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.loc.gov/mads/rdf/v1#code> "ren" .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ren> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who prepares drawings of architectural designs (i.e., renderings) in accurate, representational perspective to show what the project will look like when completed"@en .
+
+# END /vocabulary/relators/ren
+
+# BEGIN /vocabulary/relators/res
+
+_:n1f7c62ea7e5c483f89dea74fe6561031b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Performer of research" .
+_:n1f7c62ea7e5c483f89dea74fe6561031b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#code> "res" .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n1f7c62ea7e5c483f89dea74fe6561031b1 .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for performing research"@en .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Researcher" .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/res> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/res
+
+# BEGIN /vocabulary/relators/rev
+
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization responsible for the review of a book, motion picture, performance, etc."@en .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Reviewer" .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.loc.gov/mads/rdf/v1#code> "rev" .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rev> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/rev
+
+# BEGIN /vocabulary/relators/rpc
+
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Producer" .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/pro> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Radio producer" .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A producer responsible for most of the business aspects of a radio program"@en .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#code> "rpc" .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rpc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/rpc
+
+# BEGIN /vocabulary/relators/rps
+
+<http://id.loc.gov/vocabulary/relators/rps> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An organization that hosts data or material culture objects and provides services to promote long term, consistent and shared use of those data or objects"@en .
+<http://id.loc.gov/vocabulary/relators/rps> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rps> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rps> <http://www.loc.gov/mads/rdf/v1#code> "rps" .
+<http://id.loc.gov/vocabulary/relators/rps> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Repository" .
+<http://id.loc.gov/vocabulary/relators/rps> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/rps
+
+# BEGIN /vocabulary/relators/rpt
+
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.loc.gov/mads/rdf/v1#code> "rpt" .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who writes or presents reports of news or current events on air or in print"@en .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Reporter" .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/rpt> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/rpt
+
+# BEGIN /vocabulary/relators/rpy
+
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Responsible party" .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization legally responsible for the content of the published material"@en .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.loc.gov/mads/rdf/v1#code> "rpy" .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/rpy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/rpy
+
+# BEGIN /vocabulary/relators/rse
+
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/rsp> .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A respondent against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent" .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent-appellee" .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#code> "rse" .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/rse
+
+# BEGIN /vocabulary/relators/rsg
+
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Restager" .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization, other than the original choreographer or director, responsible for restaging a choreographic or dramatic work and who contributes minimal new content"@en .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.loc.gov/mads/rdf/v1#code> "rsg" .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rsg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/rsg
+
+# BEGIN /vocabulary/relators/rsp
+
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation"@en .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rse> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent-appellee" .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/rse> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent-appellant" .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#code> "rsp" .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/rst> .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent" .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/rsp
+
+# BEGIN /vocabulary/relators/rsr
+
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization responsible for the set of technical, editorial, and intellectual procedures aimed at compensating for the degradation of an item by bringing it back to a state as close as possible to its original condition"@en .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#code> "rsr" .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rsr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Restorationist" .
+
+# END /vocabulary/relators/rsr
+
+# BEGIN /vocabulary/relators/rst
+
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent-appellant" .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Respondent" .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#code> "rst" .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/rsp> .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rst> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A respondent who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"@en .
+<http://id.loc.gov/vocabulary/relators/rsp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/rst
+
+# BEGIN /vocabulary/relators/rth
+
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Research team head" .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.loc.gov/mads/rdf/v1#code> "rth" .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who directed or managed a research project"@en .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/rth> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/rth
+
+# BEGIN /vocabulary/relators/rtm
+
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who participated in a research project but whose role did not involve direction or management of it"@en .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.loc.gov/mads/rdf/v1#code> "rtm" .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Research team member" .
+<http://id.loc.gov/vocabulary/relators/rtm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/rtm
+
+# BEGIN /vocabulary/relators/sad
+
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Scientific advisor" .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who brings scientific, pedagogical, or historical competence to the conception and realization on a work, particularly in the case of audio-visual items"@en .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.loc.gov/mads/rdf/v1#code> "sad" .
+<http://id.loc.gov/vocabulary/relators/sad> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/sad
+
+# BEGIN /vocabulary/relators/sce
+
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Revised MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is the author of a motion picture screenplay, generally the person who wrote the scenarios for a motion picture during the silent era"@en .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Scenarist" .
+<http://id.loc.gov/vocabulary/relators/sce> <http://www.loc.gov/mads/rdf/v1#code> "sce" .
+
+# END /vocabulary/relators/sce
+
+# BEGIN /vocabulary/relators/scl
+
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Sculptor" .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/art> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An artist responsible for creating a three-dimensional work by modeling, carving, or similar technique"@en .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDACreator> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#code> "scl" .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Artist" .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/scl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/art> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/scl
+
+# BEGIN /vocabulary/relators/scr
+
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who is an amanuensis and for a writer of manuscripts proper. For a person who makes pen-facsimiles, use Facsimilist [fac]"@en .
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.loc.gov/mads/rdf/v1#code> "scr" .
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Scribe" .
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/scr> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+
+# END /vocabulary/relators/scr
+
+# BEGIN /vocabulary/relators/sds
+
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who produces and reproduces the sound score (both live and recorded), the installation of microphones, the setting of sound levels, and the coordination of sources of sound for a production"@en .
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.loc.gov/mads/rdf/v1#code> "sds" .
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Sound designer" .
+<http://id.loc.gov/vocabulary/relators/sds> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/sds
+
+# BEGIN /vocabulary/relators/sec
+
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.loc.gov/mads/rdf/v1#code> "sec" .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is a recorder, redactor, or other person responsible for expressing the views of a organization"@en .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sec> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Secretary" .
+
+# END /vocabulary/relators/sec
+
+# BEGIN /vocabulary/relators/sgd
+
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization contributing to a stage resource through the overall management and supervision of a performance"@en .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Stage director" .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#code> "sgd" .
+<http://id.loc.gov/vocabulary/relators/sgd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+
+# END /vocabulary/relators/sgd
+
+# BEGIN /vocabulary/relators/sgn
+
+<http://id.loc.gov/vocabulary/relators/sgn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person whose signature appears without a presentation or other statement indicative of provenance. When there is a presentation statement, use Inscriber [ins]."@en .
+<http://id.loc.gov/vocabulary/relators/sgn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sgn> <http://www.loc.gov/mads/rdf/v1#code> "sgn" .
+<http://id.loc.gov/vocabulary/relators/sgn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sgn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Signer" .
+<http://id.loc.gov/vocabulary/relators/sgn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/sgn
+
+# BEGIN /vocabulary/relators/sht
+
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nd21c2906ddcb4d72845e4d320fa9c151b1 .
+_:nd21c2906ddcb4d72845e4d320fa9c151b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization that supports (by allocating facilities, staff, or other resources) a project, program, meeting, event, data objects, material culture objects, or other entities capable of support"@en .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+_:nd21c2906ddcb4d72845e4d320fa9c151b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Host, supporting" .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Supporting host" .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sht> <http://www.loc.gov/mads/rdf/v1#code> "sht" .
+
+# END /vocabulary/relators/sht
+
+# BEGIN /vocabulary/relators/sll
+
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOwner> .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Former owner" .
+<http://id.loc.gov/vocabulary/relators/fmo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A former owner of an item who sold that item to another owner"@en .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Seller" .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#code> "sll" .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/fmo> .
+<http://id.loc.gov/vocabulary/relators/sll> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAItem> .
+
+# END /vocabulary/relators/sll
+
+# BEGIN /vocabulary/relators/sng
+
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+_:nab0ceb369d2d42f5b8f14ea033d62b9cb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by using his/her/their voice, with or without instrumental accompaniment, to produce music. A singer’s performance may or may not include actual words"@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nab0ceb369d2d42f5b8f14ea033d62b9cb1 .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+_:nab0ceb369d2d42f5b8f14ea033d62b9cb1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Vocalist" .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Singer" .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#code> "sng" .
+<http://id.loc.gov/vocabulary/relators/sng> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def; Vocalist is deprecated and made reference"@en .
+
+# END /vocabulary/relators/sng
+
+# BEGIN /vocabulary/relators/spk
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by speaking words, such as a lecture, speech, etc."@en .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#code> "spk" .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Speaker" .
+<http://id.loc.gov/vocabulary/relators/spk> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+
+# END /vocabulary/relators/spk
+
+# BEGIN /vocabulary/relators/spn
+
+_:n404fe70cdaf94017a0e5e38f340f6574b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n404fe70cdaf94017a0e5e38f340f6574b1 .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+_:n404fe70cdaf94017a0e5e38f340f6574b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Sponsoring body" .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event"@en .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#code> "spn" .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/spn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Sponsor" .
+
+# END /vocabulary/relators/spn
+
+# BEGIN /vocabulary/relators/spy
+
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who is identified as the party of the second part. In the case of transfer of right, this is the assignee, transferee, licensee, grantee, etc. Multiple parties can be named jointly as the second party"@en .
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.loc.gov/mads/rdf/v1#code> "spy" .
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/spy> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Second party" .
+
+# END /vocabulary/relators/spy
+
+# BEGIN /vocabulary/relators/srv
+
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#code> "srv" .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a cartographic resource by providing measurements or dimensional relationships for the geographic area represented"@en .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Surveyor" .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/srv> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+
+# END /vocabulary/relators/srv
+
+# BEGIN /vocabulary/relators/std
+
+<http://id.loc.gov/vocabulary/relators/std> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.loc.gov/mads/rdf/v1#code> "std" .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Set designer" .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who translates the rough sketches of the art director into actual architectural structures for a theatrical presentation, entertainment, motion picture, etc. Set designers draw the detailed guides and specifications for building the set"@en .
+<http://id.loc.gov/vocabulary/relators/std> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/std
+
+# BEGIN /vocabulary/relators/stg
+
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Setting" .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Subject relationship"@en .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An entity in which the activity or plot of a work takes place, e.g. a geographic place, a time period, a building, an event"@en .
+<http://id.loc.gov/vocabulary/relators/stg> <http://www.loc.gov/mads/rdf/v1#code> "stg" .
+
+# END /vocabulary/relators/stg
+
+# BEGIN /vocabulary/relators/stl
+
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Storyteller" .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by relaying a creator’s original story with dramatic or theatrical interpretation"@en .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#code> "stl" .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/stl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+
+# END /vocabulary/relators/stl
+
+# BEGIN /vocabulary/relators/stm
+
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.loc.gov/mads/rdf/v1#code> "stm" .
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who is in charge of everything that occurs on a performance stage, and who acts as chief of all crews and assistant to a director during rehearsals"@en .
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/stm> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Stage manager" .
+
+# END /vocabulary/relators/stm
+
+# BEGIN /vocabulary/relators/stn
+
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An organization responsible for the development or enforcement of a standard"@en .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.loc.gov/mads/rdf/v1#code> "stn" .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/stn> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Standards body" .
+
+# END /vocabulary/relators/stn
+
+# BEGIN /vocabulary/relators/str
+
+<http://id.loc.gov/vocabulary/relators/str> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/str> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Stereotyper" .
+<http://id.loc.gov/vocabulary/relators/str> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who creates a new plate for printing by molding or copying another printing surface"@en .
+<http://id.loc.gov/vocabulary/relators/str> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/str> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/str> <http://www.loc.gov/mads/rdf/v1#code> "str" .
+
+# END /vocabulary/relators/str
+
+# BEGIN /vocabulary/relators/tcd
+
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person who is ultimately in charge of scenery, props, lights and sound for a production"@en .
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.loc.gov/mads/rdf/v1#code> "tcd" .
+<http://id.loc.gov/vocabulary/relators/tcd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Technical director" .
+
+# END /vocabulary/relators/tcd
+
+# BEGIN /vocabulary/relators/tch
+
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/prf> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Performer" .
+_:nbd4757da5877472c81fecb0fdb52a966b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#code> "tch" .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/prf> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A performer contributing to a resource by giving instruction or providing a demonstration"@en .
+_:nbd4757da5877472c81fecb0fdb52a966b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Instructor" .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nbd4757da5877472c81fecb0fdb52a966b1 .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Teacher" .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/tch> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+
+# END /vocabulary/relators/tch
+
+# BEGIN /vocabulary/relators/ths
+
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person under whose supervision a degree candidate develops and presents a thesis, mémoire, or text of a dissertation"@en .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+_:ne0ab2a55169b4242acf849656e7255b9b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Promoter" .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Thesis advisor" .
+_:ne0ab2a55169b4242acf849656e7255b9b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:ne0ab2a55169b4242acf849656e7255b9b1 .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/ths> <http://www.loc.gov/mads/rdf/v1#code> "ths" .
+
+# END /vocabulary/relators/ths
+
+# BEGIN /vocabulary/relators/tld
+
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/drt> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Director" .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/drt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#code> "tld" .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Television director" .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tld> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A director responsible for the general management and supervision of a television program"@en .
+
+# END /vocabulary/relators/tld
+
+# BEGIN /vocabulary/relators/tlp
+
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAWork> .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A producer responsible for most of the business aspects of a television program"@en .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAOther> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Producer" .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Television producer" .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/pro> .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#code> "tlp" .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/pro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tlp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/tlp
+
+# BEGIN /vocabulary/relators/trc
+
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Changed MARC def"@en .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#code> "trc" .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Transcriber" .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by changing it from one system of notation to another. For a work transcribed for a different instrument or performing group, see Arranger [arr]. For makers of pen-facsimiles, use Facsimilist [fac]"@en .
+<http://id.loc.gov/vocabulary/relators/trc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+
+# END /vocabulary/relators/trc
+
+# BEGIN /vocabulary/relators/trl
+
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Translator" .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who renders a text from one language into another, or from an older form of a language into the modern form"@en .
+<http://id.loc.gov/vocabulary/relators/trl> <http://www.loc.gov/mads/rdf/v1#code> "trl" .
+
+# END /vocabulary/relators/trl
+
+# BEGIN /vocabulary/relators/tyd
+
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n98a94c86eddc47b8a69c8420110196c7b1 .
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Type designer" .
+_:n98a94c86eddc47b8a69c8420110196c7b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who designs the type face used in a particular item"@en .
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/tyd> <http://www.loc.gov/mads/rdf/v1#code> "tyd" .
+_:n98a94c86eddc47b8a69c8420110196c7b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Designer of type" .
+
+# END /vocabulary/relators/tyd
+
+# BEGIN /vocabulary/relators/tyg
+
+<http://id.loc.gov/vocabulary/relators/tyg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Typographer" .
+<http://id.loc.gov/vocabulary/relators/tyg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/tyg> <http://www.loc.gov/mads/rdf/v1#code> "tyg" .
+<http://id.loc.gov/vocabulary/relators/tyg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization primarily responsible for choice and arrangement of type used in an item. If the typographer is also responsible for other aspects of the graphic design of a book (e.g., Book designer [bkd]), codes for both functions may be needed"@en .
+<http://id.loc.gov/vocabulary/relators/tyg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/tyg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/tyg
+
+# BEGIN /vocabulary/relators/uvp
+
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "University place" .
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.loc.gov/mads/rdf/v1#code> "uvp" .
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A place where a university that is associated with a resource is located, for example, a university where an academic dissertation or thesis was presented"@en .
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/uvp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/uvp
+
+# BEGIN /vocabulary/relators/vac
+
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Actor" .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/act> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/act> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#definitionNote> "An actor contributing to a resource by providing the voice for characters in radio and audio productions and for animated characters in moving image works, as well as by providing voice overs in radio and television commercials, dubbed resources, etc."@en .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#code> "vac" .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/vac> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Voice actor" .
+
+# END /vocabulary/relators/vac
+
+# BEGIN /vocabulary/relators/vdg
+
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Videographer" .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person in charge of a video production, e.g. the video recording of a stage production as opposed to a commercial motion picture. The videographer may be the camera operator or may supervise one or more camera operators. Do not confuse with cinematographer"@en .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#editorialNote> "In RDA included under Director of photography (i.e. cinematographer)"@en .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/vdg> <http://www.loc.gov/mads/rdf/v1#code> "vdg" .
+
+# END /vocabulary/relators/vdg
+
+# BEGIN /vocabulary/relators/voc
+
+_:n0409005cc86f44fb9f3e7fda79c3af98b1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Singer" .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:n0409005cc86f44fb9f3e7fda79c3af98b1 .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority> .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.loc.gov/mads/rdf/v1#code> "voc" .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.loc.gov/mads/rdf/v1#deprecatedLabel> "Vocalist" .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/voc> <http://www.loc.gov/mads/rdf/v1#editorialNote> "Combined with Singer (sng)"@en .
+_:n0409005cc86f44fb9f3e7fda79c3af98b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+
+# END /vocabulary/relators/voc
+
+# BEGIN /vocabulary/relators/wac
+
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of added commentary" .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#code> "wac" .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to an expression of a work by providing an interpretation or critical explanation of the original work"@en .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/wst> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of supplementary textual content" .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/wac
+
+# BEGIN /vocabulary/relators/wal
+
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of added lyrics" .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of supplementary textual content" .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#code> "wal" .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A writer of words added to an expression of a musical work. For lyric writing in collaboration with a composer to form an original work, see lyricist"@en .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/wst> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+
+# END /vocabulary/relators/wal
+
+# BEGIN /vocabulary/relators/wam
+
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.loc.gov/mads/rdf/v1#code> "wam" .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of accompanying material" .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wam> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who writes significant material which accompanies a sound recording or other audiovisual material"@en .
+
+# END /vocabulary/relators/wam
+
+# BEGIN /vocabulary/relators/wat
+
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#code> "wat" .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a non-textual resource by providing text for the non-textual work (e.g., writing captions for photographs, descriptions of maps)."@en .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of added text" .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of supplementary textual content" .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority> <http://id.loc.gov/vocabulary/relators/wst> .
+
+# END /vocabulary/relators/wat
+
+# BEGIN /vocabulary/relators/wdc
+
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Woodcutter" .
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.loc.gov/mads/rdf/v1#code> "wdc" .
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/wdc> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who makes prints by cutting the image in relief on the plank side of a wood block"@en .
+
+# END /vocabulary/relators/wdc
+
+# BEGIN /vocabulary/relators/wde
+
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://purl.org/dc/elements/1.1/contributor> .
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.loc.gov/mads/rdf/v1#code> "wde" .
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person or organization who makes prints by cutting the image in relief on the end-grain of a wood block"@en .
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Wood engraver" .
+<http://id.loc.gov/vocabulary/relators/wde> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+
+# END /vocabulary/relators/wde
+
+# BEGIN /vocabulary/relators/win
+
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of introduction" .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#code> "win" .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by providing an introduction to the original work"@en .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/win> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/win
+
+# BEGIN /vocabulary/relators/wit
+
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nf0445f713f6c4bd68835595536c5914ab1 .
+_:nf0445f713f6c4bd68835595536c5914ab4 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Testifier" .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+_:nf0445f713f6c4bd68835595536c5914ab1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:nf0445f713f6c4bd68835595536c5914ab4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+_:nf0445f713f6c4bd68835595536c5914ab5 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Eyewitness" .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nf0445f713f6c4bd68835595536c5914ab4 .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Witness" .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nf0445f713f6c4bd68835595536c5914ab2 .
+_:nf0445f713f6c4bd68835595536c5914ab5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:nf0445f713f6c4bd68835595536c5914ab3 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Deponent" .
+_:nf0445f713f6c4bd68835595536c5914ab2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nf0445f713f6c4bd68835595536c5914ab3 .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+_:nf0445f713f6c4bd68835595536c5914ab1 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Onlooker" .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#code> "wit" .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:nf0445f713f6c4bd68835595536c5914ab5 .
+_:nf0445f713f6c4bd68835595536c5914ab2 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Observer" .
+_:nf0445f713f6c4bd68835595536c5914ab3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#definitionNote> "Use for a person who verifies the truthfulness of an event or action."@en .
+<http://id.loc.gov/vocabulary/relators/wit> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+
+# END /vocabulary/relators/wit
+
+# BEGIN /vocabulary/relators/wpr
+
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#code> "wpr" .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of preface" .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by providing a preface to the original work"@en .
+<http://id.loc.gov/vocabulary/relators/wpr> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+
+# END /vocabulary/relators/wpr
+
+# BEGIN /vocabulary/relators/wst
+
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wac> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of added commentary" .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of added text" .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_PastPresentRelatorsEntries> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of supplementary textual content" .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAContributor> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/wal> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_BIBFRAMEWork> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDAExpression> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#definitionNote> "A person, family, or organization contributing to a resource by providing supplementary textual content (e.g., an introduction, a preface) to the original work"@en .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Writer of added lyrics" .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#code> "wst" .
+<http://id.loc.gov/vocabulary/relators/wat> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/relators/collection_RDA> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/wac> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority> <http://id.loc.gov/vocabulary/relators/wat> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/vocabulary/relators/wst> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/relators> .
+
+# END /vocabulary/relators/wst
+

--- a/data/ohrc117.xml
+++ b/data/ohrc117.xml
@@ -1,0 +1,1455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 https://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid countrycode="US" mainagencycode="US-InU">ohrc117</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>
+          Coming Together: An Oral History of the Ostroms and their Scholarly Impact on Problem Solving, 2014
+          <num>ohrc117</num>
+        </titleproper>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>Center for Documentary Research and Practice</publisher>
+        <p id="logostmt">
+          <extref xlink:actuate="onLoad" xlink:href="http://webapp1.dlib.indiana.edu/archivesOnline/repositoryImages/cshm.jpg" xlink:show="embed" xlink:type="simple"/>
+        </p>
+        <address>
+          <addressline>Franklin Hall 0030B</addressline>
+          <addressline>601 E. Kirkwood Avenue</addressline>
+          <addressline>Bloomington, Indiana 47405</addressline>
+          <addressline>Business Number: 812-855-2856</addressline>
+          <addressline>ohrc@iu.edu</addressline>
+          <addressline>
+            URL:
+            <extptr xlink:href="https://cdrp.mediaschool.indiana.edu/" xlink:show="new" xlink:title="https://cdrp.mediaschool.indiana.edu/" xlink:type="simple"/>
+          </addressline>
+        </address>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>
+        This finding aid was produced using ArchivesSpace on
+        <date>2025-04-20 23:46:43 -0400</date>
+        .
+      </creation>
+      <langusage>
+        Description is written in:
+        <language langcode="eng" scriptcode="Latn">English, Latin script</language>
+        .
+      </langusage>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>03-01-2021</date>
+        <item>ArchiveSpace Resource Created by Anna Wilson</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>Center for Documentary Research and Practice</corpname>
+      </repository>
+      <unittitle>Coming Together: An Oral History of the Ostroms and their Scholarly Impact on Problem Solving</unittitle>
+      <origination label="Creator">
+        <corpname role="his" source="lcnaf">Indiana University Center for the Study of History and Memory</corpname>
+      </origination>
+      <unitid>ohrc117</unitid>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">32 Interviews</extent>
+        <physfacet>Audio files and transcripts</physfacet>
+      </physdesc>
+      <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014/2014">2014</unitdate>
+      <physdesc audience="internal" id="aspace_3247a8ba5eaeb5e21bd2f2d5429a6526">Contains interviews consisting of audio .wav files and transcripts.</physdesc>
+      <abstract audience="internal" id="aspace_0575cb92949f9e3fa0eec177c7637901" label="Scope and Content Note">This project centers around interviews with professional and/or personal acquaintances of Elinor and Vincent Ostrom. Every interview explores a unique relationship with the Ostroms and the continuing impact of the Ostrom Workshop at Indiana University. Elinor (Lin) and Vincent Ostrom founded the Workshop in Political Theory and Policy Analysis in 1973.The Ostrom Workshop has been the catalyst for worldwide collaboration in the field of public policy and environmental issues. "Coming Together" is an interdisciplinary exploration of the legacy and impact of Elinor (Lin) and Vincent Ostrom. Major topics include; academia, "the commons", cross-disciplinary collaboration, Elinor Ostrom's Nobel Prize, the Ostrom Workshop, political science, political theory, and the Workshop on the Ostrom Workshop (WOW) conference. The project was created to assist in the dissertation research of Sara Catherine Clark, who was a doctoral candidate within the School of Education, pursing a Ph.D. in History, Philosophy, and Policy in Education, at Indiana University Bloomington. Sara Catherine Clark's dissertation was completed in 2019 and is cited as follows: Clark, S. C. (2019).
+        <title render="italic">Elinor ostrom: A biography of interdisciplinary life.</title>
+      </abstract>
+      <physloc id="aspace_fb52b7ff7a5a06d4a912a92580cc0bdf" label="Physical Location">Interviews are housed in Franklin Hall, Room 0030A. Contact ohrc@indiana.edu for more information. Copies of interview transcripts are also held by the IU Libraries University Archives. For other locations housing the interviews from this project, please contact the Center for Documentary Research and Practice office.</physloc>
+      <langmaterial>
+        <language langcode="eng" scriptcode="Latn">English</language>
+        .
+      </langmaterial>
+    </did>
+    <accessrestrict audience="internal" id="aspace_b0a1f983695e8d0c7a090e755ebfeba0">
+      <head>Access Status</head>
+      <p>Access varies by interview.</p>
+    </accessrestrict>
+    <userestrict id="aspace_853c849baab55962a4bc8bfa0180ef75">
+      <head>Usage Restrictions</head>
+      <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+    </userestrict>
+    <prefercite id="aspace_19d6d783c2fd59dcfff14d2a78681ea6">
+      <head>Preferred Citation</head>
+      <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+    </prefercite>
+    <dsc>
+      <c01 audience="internal" id="aspace_15dbd244db1d8522681ccc586bb85973" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Aligica, Paul Dragos</unittitle>
+          <unitid>14-010</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-18/2014-06-18">June 18, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_4c8647d7d0bf0b080b520b1e8157762c" label="Physical Description">20 pages; 3 .wav files, 56 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_980387bc38e008851f4a0412f518b07e">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_700813a5abf406c51d0489d6f5f470c6">
+          <head>Scope Note</head>
+          <p>Dr. Paul Dragos Aligica is a professor in the Economics Department in Politics and Economics at Mercatus Center at George Mason University. Dragos Aligica first met Elinor and Vincent Ostrom at the Workshop but was familiar with their work before arriving there. He discusses the way academic institutions work and the way the Ostroms didn't conform to those rules. Later he discusses collaborating with the Ostroms through the Ostrom Workshop. Dragos Aligica also recalls Elinor Ostrom as a teacher and her humor. He goes on to discuss how the Ostroms intellectual lineage will be looked at in the future. The interview concludes with talk about the Workshop on the Ostrom Workshop (WOW) Conference and a more in-depth talk about the Ostrom Workshop.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_6327461968924a1f0f633ca7ed257106">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_6853d023bbf4dd88a515b0fd42476e7a">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <subject source="local">Academia</subject>
+          <subject source="local">institutional theory</subject>
+          <subject source="local">Institutional Analysis and Development Framework (IAD)</subject>
+          <occupation source="local">professor</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_7308b3db3cc4a992a7a3834b20394808" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Anonymous</unittitle>
+          <unitid>14-024</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-26/2014-06-26">June 26, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_54b6838168a4a00c4087199321fab61a" label="Physical Description">17 pages; no audio files; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_397125dd919a69abb41130c620f1087d">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_aef805b1359661d2ee335e84e5abe612">
+          <head>Scope Note</head>
+          <p>Anonymous begins the interview by explaining their connection to Elinor Ostrom as a student in the political science department. This leads to discussion of Ostrom as a teacher, working with her on the Health Commons Research Project, and experiences with her at the Ostrom Workshop. They speak of the Occupy Movement as an important part of their academic career and the connection to Ostrom's work. Anonymous goes on to discuss how they would tell the Ostroms' story which includes discussion of the Nobel Prize in Economics. Then Anonymous is asked to discuss lingering research questions, those questions deal with power and the colonial experience within the commons. The interview closes discussing the Ostrom Workshop and Elinor Ostrom's work on language.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_140f2ddd43e12b11c4deca41032e1810">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_21449738d93e9568002efab6770bbb1a">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">health commons</subject>
+          <subject source="local">Midnight Notes Collective</subject>
+          <subject source="local">Occupy Movement</subject>
+          <subject source="local">social movements as commons</subject>
+          <occupation source="ingest">student</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_d25a4b5089d7d99e68eace6db842224c" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Bal, Mansee</unittitle>
+          <unitid>14-022</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-21/2014-06-21">June 21, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_82da4834189b9209bd0d9abd8a97e2bb" label="Physical Description">21 pages; 1 .wav files, 55 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_a2ef2bc06f6f6d249e588b1efec6dcae">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_431310f2e8ee6d0ca931af4c55881746">
+          <head>Scope Note</head>
+          <p>Mansee Bal is a Research Entrepreneur with the Environmental Design Consultants in India. Bal first discovered Elinor Ostrom when she began reading for her PhD program at Erasmus University. Bal's research focused on urban lakes, mainly in India with a multidisciplinary focus. After this initial introduction Bal had the opportunity to work with Ostrom at the Ostrom Workshop. Throughout the interview she fondly recalls having Elinor Ostrom as a teacher, Ostrom winning the Nobel Prize, Workshop on the Ostrom Workshop (WOW) Conference and personal memories with Ostrom.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_9bd08cb747e70730591d1b0db5a30ba3">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_4596fe1ad5c1417e89c40a22c29d2453">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <geogname source="ingest">India</geogname>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">"Planet Under Pressure" Conference</subject>
+          <occupation source="local">Research Entrepreneur</occupation>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <subject source="local">Urban Lakes System</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_9036dc52560abc11cbc34a3a983957a2" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Basurto, Xavier</unittitle>
+          <unitid>14-029</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-07-17/2014-07-17">July 17, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_7e2b25937c606432ce8484acb34689b3" label="Physical Description">17 pages; 1 .wav file, 81 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_6e3631a6915cc067b1fe56f5e43161f6">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_fd64b72b19489f4db361b402a3ed1bd2">
+          <head>Scope Note</head>
+          <p>Xavier Basurto is an Associate Professor of Sustainability Science within the division of Marine Science & Conservation at Duke University. Basurto met Elinor Ostrom through Edella Schlager, a professor at University of Arizona. After finished his PhD he applied for a postdoc position at the Ostrom Workshop, which he was accepted to. Basurto later talks about Elinor Ostrom's influence and his participation in the Workshop on the Ostrom Workshop (WOW) Conferences.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_66240d6712a8ee2e5b826955ee01f197">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_fd3c083c68c02d68cb7f739dcb7cc310">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">Duke University</subject>
+          <subject source="local">Fisheries</subject>
+          <subject source="local">Nobel Prize</subject>
+          <occupation source="local">professor</occupation>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_b7876d9c1d0f691746d1e8317243727d" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Bish, Robert</unittitle>
+          <unitid>14-003</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-13/2014-06-13">June 13, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_69c5b8607eb103df26ff6438c56fe7ad" label="Physical Description">23 pages; 1 .wav file, 67 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_005269ad20a9b9cfa3a9d3713a33cdf5">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_077a0c874e2a380813e8c65cf8a3125c">
+          <head>Scope Note</head>
+          <p>Robert Bish is Professor Emeritus in the School of Public Administration at the University of Victoria. Bish first met Vincent Ostrom when he enrolled in Ostrom's PhD class, public administration. Later, Bish met Elinor Ostrom when she visited a class taught by Vincent Ostrom. Later Bish discusses the both Elinor and Vincent's research, their generosity and the Public Choice Society.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_6f42e289723451aa9c9cd73f74b5075a">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_adca970f5600fdeee81bb22cc6e01bd7">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject authfilenumber="sh85040850" source="lcsh">economics</subject>
+          <subject source="lcnaf">Markets</subject>
+          <subject source="local">political economy research</subject>
+          <subject source="ingest">political science</subject>
+          <occupation source="local">professor</occupation>
+          <subject source="local">water resource research</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_552d3c4039adcfa09ac39ea9e0c75d01" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Bower-Bir, Jacob</unittitle>
+          <unitid>14-007</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-17/2014-06-17">June 17, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_1b1b5c0a6431a861bc61ab9057a94f02" label="Physical Description">22 pages; 1 .wav files, 79 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_3875282a82eb4804269d01de08b5cfe1">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_e67145eb8f044281fb97631b137883ba">
+          <head>Scope Note</head>
+          <p>Jacob Bower-Bir is an Assistant Professor at the American University in Cairo. He first met Elinor Ostrom as a student where she was his mentor for five years and chair of his committee. Bower-Bir recalls how fortunate he was to work with Elinor Ostrom before and after the Nobel prize. He also discusses the Ostrom Workshop, the Workshop on the Ostrom Workshop and questions both the Ostroms were pursing answers to. The interview closes with Bower-Bir reflecting on the ways Elinor and Vincent Ostrom influenced him.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_5825f4f7f29e86b98c18b880f6248680">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_0c3fcab6ad4fc06bc34220a67b487905">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <occupation source="ingest">professor</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_91d331e34c92742304df4ad2f69d282a" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Brondizio, Eduardo</unittitle>
+          <unitid>14-011</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-20/2014-06-20">June 20, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_3e04d06742e5cfa4af59a4a91bf28697" label="Physical Description">13 pages; 1 .wav files, 61 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_4be03fdc31c36c9a0fc743a8c08a682c">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_c78f79dfef2e272d765629a173e8a447">
+          <head>Scope Note</head>
+          <p>Eduardo Brondizio is a professor of Anthropology at Indiana University. He met Elinor Ostrom while developing a proposal for a Center of excellence on the study of population, institutions, and environmental change (CIPEC). He discusses the way the Ostroms built teams by creating a space where common language was upheld above discipline specific language and the overarching idea of research around problems, not disciplines. He goes on to describe how he began working at the Ostrom Workshop and what he does there now. Personal and last memories of Elinor Ostrom are also shared.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_266d738c8b3f4de15023d8818141107b">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_ad2ea4fbed615b9ee5389ffd888d5c04">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">collaborative learning</subject>
+          <subject source="local">cross-disciplinary teamwork</subject>
+          <geogname source="ingest">France</geogname>
+          <subject source="local">interdisciplinary research</subject>
+          <occupation source="ingest">professor</occupation>
+          <corpname rules="rda" source="local">Center of Excellence of the Study of Population, Institutions, and Environmental Change (CIPEC)</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_1896d01712dd2fd08f20cb9802cc27d5" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Bruns, Bryan</unittitle>
+          <unitid>14-023</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="bce" normal="2014-06-21/2014-06-21">June 21, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_b72253a9fb91a0df0b9040f56505c536" label="Physical Description">18 pages; 2 .wav files; 51 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_626ae126b3b2824016b72d4e34f0e1cd">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_58bf5506f806e0f9a72e8d2d05f9988e">
+          <head>Scope Note</head>
+          <p>Bryan Bruns is an Independent Consultant Sociologist. Bruns was exposed to the work of Elinor and Vincent Ostrom through mutual colleagues, conferences, and their writing. In 2009 Bruns became a Visiting Scholar at the Ostrom Workshop. He discusses what it was like to be a part of the Ostrom Workshop and the way Elinor Ostrom taught. Later he discusses his own work, Workshop on the Ostrom Workshop, and the Nobel Prize.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_63607d70ee2aa04bc613556d57b53c26">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_a6be7c2ad6c37b6b4394988099b2b431">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">irrigation</subject>
+          <subject source="local">Nobel Prize</subject>
+          <occupation source="local">sociologist</occupation>
+          <subject source="local">"The Federalist Papers"</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <persname rules="rda" source="local">Coward, Walt</persname>
+          <corpname rules="rda" source="local">International Association for Study of the Commons (IASC)</corpname>
+          <persname role="aut" rules="rda" source="lcnaf">de Tocqueville, Alexis, 1805-1859</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_f1dfa268f09dab878ec638f0e19c74ad" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Castle, Emily</unittitle>
+          <unitid>14-028</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-07-15/2014-07-15">July 15, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_c5787156860efe96686a4360d0f51cb4" label="Physical Description">21 pages; 1 .wav file, 65 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_26dd1cc38fc034154fb4c08bdb0b61cb">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_0313940f5b54c44ba1f19637a8830009">
+          <head>Scope Note</head>
+          <p>Emily Castle is the Assistant Director and Librarian at the Ostrom Workshop. She first met Elinor Ostrom at a staff meeting and Elinor was a supervisor of Castle. Castle describes the Ostrom Workshop Library and her typical day as a Librarian. She later discusses preparing and planning the Workshop on the Ostrom Workshop conference. In time she discusses the physical space at the Ostrom Workshop and the community. Castle finishes her interview discussing Elinor Ostrom as a Supervisor, the Nobel Prize, and the Ostrom Workshop without the Ostroms.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_fe9b941543a6a8f87850a211eabb4005">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_06a73b39eff5340ca533d6937eabca9a">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">library profession</subject>
+          <occupation source="ingest">librarian</occupation>
+          <occupation source="ingest">library director</occupation>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_12fb543018fdb3d20c628c53303dd16f" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Cole, Daniel</unittitle>
+          <unitid>14-002</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-03/2014-06-03">June 03, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_26cd8753e15ffe0cf22ed2323266bc77" label="Physical Description">15 pages; 1 .wav file, 63 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_f345cd9d94b1428b48eeea8cf5a91bf8">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_a03ed8e9bf24179852bab09935a9d2aa">
+          <head>Scope Note</head>
+          <p>Daniel Cole is a professor of Law and Public and Environment Health at the Maurer School of Law at Indiana University. The interview begins with Cole explaining how he first met Elinor Ostrom at the Ostrom Workshop and became more familiar with her through a cooperative forestry group and conferences which eventually led to Cole joining the Workshop Advisory Council. He speaks of Elinor Ostrom as a teacher, personal and professional experiences with the Ostroms, and team building in the Ostrom Workshop. Cole tells of the personal conversations he had with Elinor Ostrom in the hospital and how humorous and warm she was. He discusses what he think Ostrom's favorite time of the week was, the Workshop colloquium. The discussion ends with Cole talking about the book he and Elinor Ostrom wrote titled "Property in Land and Other Resources".</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_cbf165298d5f8171eb477c23c2ec0c1d">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_4c2946e7811d76f50675a23d2ad69ce9">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">environmental law</subject>
+          <geogname authfilenumber="n79055094" source="lcsh">Indianapolis (Ind.)</geogname>
+          <occupation source="ingest">professor</occupation>
+          <subject source="local">"Property in Land and Other Resources"</subject>
+          <subject source="ingest">teaching</subject>
+          <subject source="local">team building</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <corpname rules="rda" source="local">Lincoln Institute of Land Policy</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_e39cbe5fb343191742d72cc7209ef507" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>DeCaro, Daniel</unittitle>
+          <unitid>14-016</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-20/2014-06-20">June 20, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_6c21e7adf6325a852011dd61a43d23db" label="Physical Description">21 pages; 1 .wav file, 56 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_e056c20a9e8fb28225d0c1b120f491df">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_55d884497e240dd26c8216949a0295e7">
+          <head>Scope Note</head>
+          <p>Daniel DeCaro is an Assistant Professor winthin the Department of Psychological and Brain Sciences at the University of Louisville. He first met Elinor and Vincent Ostrom when he applied to the Ostrom Workshop for a visiting scholar position, which he started in August 2010. With a background in psychology, DeCaro has a unique perspective in the Ostrom Workshop and the classes he was enrolled in. DeCaro was a visiting scholar for three years which he reflects on by sharing his interactions with Elinor Ostrom and the project he has been working on which has been presented at the Workshop on the Ostrom Workshop. DeCaro closes the interview by discussing challenges to interdisciplinary research.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_a64a493a6cf26d68df6555cb5fe509e0">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_161e9d3f674d3637891c25ac70e62e81">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">interdisciplinary research</subject>
+          <subject source="local">interdisciplinary social science research </subject>
+          <subject source="ingest">Psychology</subject>
+          <subject source="local">self-governance</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <occupation source="ingest">professor</occupation>
+          <occupation source="local">visiting scholar</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_784a1aedb4a702882b91a16aac4a1cab" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>DeMoor, Martina (Tine)</unittitle>
+          <unitid>14-015</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-20/2014-06-20">June 20, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_7d303ea1e2b9a6629d1f25c433296aa6" label="Physical Description">14 pages; 1 .wav file, 43 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_c1650c6a843071d36af51700bad78a59">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_6e9c6d09ae025eee479ea49a0c9bffa0">
+          <head>Scope Note</head>
+          <p>Martina (Tine) DeMoor is a Professor of Institutions for Collective Action in Historical Perspective and a research leader at the Economic and Social History research group, Faculty of Humanities at Utrecht University. In this interview she discusses how she first knew of Elinor (Lin) Ostrom by reading her book Governing the Commons which resulted in her reaching out to Ostrom. The rest of the interview discusses the founding of the International Journal of the Commons, the 2014 Workshop on the Ostrom Workshop (WOW) Conference, and DeMoor's European tribute to Lin Ostrom.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_c4c812fd6d4357e21a19ca9c2d6c361c">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_1375856d5bce17de2098f1e8384cc0dd">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">"Governing the Commons"</subject>
+          <subject source="local">International Journal of the Commons</subject>
+          <subject source="local">leadership</subject>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <occupation source="ingest">professor</occupation>
+          <occupation source="local">historian</occupation>
+          <occupation source="local">research leader</occupation>
+          <geogname source="ingest">Chicago, Illiniois</geogname>
+          <geogname source="local">Netherlands</geogname>
+          <persname rules="rda" source="local">van Laerhoeven, Frank</persname>
+          <corpname rules="rda" source="local">International Association for Study of the Commons (IASC)</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_1c1c3c4f133139966be4687609024f40" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>England, Julie</unittitle>
+          <unitid>14-030</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-07-23/2014-07-23">July 23, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_262115e57e4ed256438c67deb11931d5" label="Physical Description">16 pages; 2 .wav files, 78 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_96ecbb54df8a8bc44ef714f523c24361">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_50bd4c172249c07ea40c8ca13332af33">
+          <head>Scope Note</head>
+          <p>Julie England is an adjunct instructor in the School of Public and Environmental Affairs at Indiana University Bloomington. England discusses her work on databases that began with the common-pool resources (CPR) database and evolved with new projects in the Ostrom Workshop. She also discusses the technological changes in the Ostrom Workshop, the creation of the Center for the Study of Institutions, Populations and Environmental Change, and the Workshop on the Workshop Conference. The interview then discusses the Ostroms on a personal level including Manitoulin Island and the Ostrom Workshop after the Ostroms.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_0783fc09070af6502d6c262f07a6faeb">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_c83402e3c32e8d602005535c11c73317">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">information technology (IT)</subject>
+          <subject source="local">common-pool resources (CPR)</subject>
+          <occupation source="local">adjunct instructor</occupation>
+          <geogname source="local">Manitoulin Island, Ontario, Canada</geogname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Food and Agricultural Organization of the United Nations (FAO),</corpname>
+          <corpname rules="rda" source="local">International Forestry Resources and Institutions (IFRI)</corpname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_8c84acc64f023be65d31163e1f443b0b" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Evans, Tom</unittitle>
+          <unitid>14-032</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-07-23/2014-07-23">July 23, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_72f3e6d927e9b810d8abb64a37c34f0e" label="Physical Description">20 pages; 2 .wav files, 60 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_57b2fe7501d96daa9a5f09377176f216">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_d0d2431d4b204f865cab0b84a3410c7b">
+          <head>Scope Note</head>
+          <p>Tom Evans is a professor at the University of Arizona in the School of Geography and Development. Evans was hired by Elinor Ostrom and Emilio Moran in 1998 as a post-doctoral scholar at the Center for the Study of Institutions, Population, and Environmental Change (CIPEC). During his post-doc he was a co-principle investigator with Elinor Ostrom, working on a biocomplexity Nation Science Foundation grant. Later, Evans became co-director of CIPEC and co-director of the Ostrom Workshop which he discusses at length. He also discusses some of the core research that was going on at the Ostrom Workshop such as the social-ecological system (SES) framework. Evans closes the interview by discussing the Workshop on the Ostrom Workshop Conference and the 2009 Nobel Prize in Economic Sciences.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_43f1e0bec8a551d50e73fbc3208b2a93">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_1f9a5edaf8dcb8352d7bd38823e7aa22">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <occupation source="ingest">professor</occupation>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local"> Social-Ecological System (SES) framework</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <corpname rules="rda" source="local">Center of Excellence of the Study of Population, Institutions, and Environmental Change (CIPEC)</corpname>
+          <corpname authfilenumber="n79005681" rules="rda" source="lcnaf">National Science Foundation (U.S.)</corpname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname rules="rda" source="local">Moran, Emilio</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_eb72ecb655a71eee1caf05182c680b90" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Fischer, Burnell</unittitle>
+          <unitid>14-008</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <origination label="Creator">
+            <corpname authfilenumber="n79005681" rules="rda" source="lcnaf">National Science Foundation (U.S.)</corpname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-18/2014-06-18">June 18, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_9ce0eb311b098f56c46cf7a32fb482e2" label="Physical Description">20 pages; 1 .wav file, 60 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_9d3c468ebb2a705996c79a1c1354e0b8">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_c8b79fbbb56c21595263f87b9073981b">
+          <head>Scope Note</head>
+          <p>Burnell Fischer is the Clinical Professor Emeritus in the School of Public and Environmental Affairs. Fischer discusses his time as the State Forester of Indiana. Fischer wanted more collaboration with a greater variety of stakeholders and he discusses how he made that work. While he was working at the State Forester of Indiana Elinor Ostrom contacted him to come down and speak to her and her graduate students. During this time a collaborative was formed between Indiana University, Purdue University, The Nature Conservancy, and Professor Dan Cole of IUPUI (now Indiana University Bloomington). Fischer then began working at Indiana University where he assisted Elinor Ostrom in teaching. His position moved from work at the Ostrom Workshop to his position as the undergraduate program director at the School of Public and Environmental Affairs. Fischer recalls his time at the Nobel ceremony and why he was there. The interview concludes discussing the Workshop on the Ostrom Workshop (WOW) and the Ostrom Workshops future.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_2e5b6b4d9f642ad9bbf8bdc7c9e24938">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_87511d27aec92a33be6f8a65913df44d">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <subject source="ingest">forestry</subject>
+          <subject source="ingest">teaching</subject>
+          <subject source="local">Nobel Prize</subject>
+          <persname rules="rda" source="local">Cole, Daniel</persname>
+          <corpname rules="rda" source="local">International Forestry Resources and Institutions (IFRI)</corpname>
+          <persname rules="rda" source="local">McGinnis, Michael</persname>
+          <corpname rules="rda" source="local">State (IN) Forestry Agency</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_80ad01f0dd817ad84f18484b0621bad9" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Frischmann, Brett</unittitle>
+          <unitid>14-0202</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-20/2014-06-20">June 20, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_6d0a44423e03600a776a8e2c04c8438b" label="Physical Description">18 pages; 1 .wav file, 52 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_b0442f2135d71a995f3c1f6eee922009">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_6419c5b4b10f0f7a5d38cf640727720d">
+          <head>Scope Note</head>
+          <p>Brett Frischmann is a law professor at Villanova University. Frischmann met Elinor Ostrom in Chicago where she gave a guest lecture at the Illinois Institute of Technology. He reflects how Elinor Ostrom influenced his research and her strengths as a mentor. He then discusses how Ostrom's work with the commons and methodologies will be looked at in the future. As an affiliate faculty member of the Ostrom Workshop, Frischmann is able to discuss his vision for the Ostrom Workshop going forward.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_f5aba23ba41bde40e4584b116f3eaeae">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_56da63544bee3d36c6dc74bd659473b3">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">the commons</subject>
+          <geogname source="ingest">Chicago Illinois</geogname>
+          <subject authfilenumber="sh85040850" source="lcsh">economics</subject>
+          <subject source="local">Institutional Analysis and Development Framework (IAD)</subject>
+          <subject source="lcsh">Law</subject>
+          <occupation source="ingest">law professor</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_4a9adbcba21d2ee517f53ece939968d8" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Hart, Jeffrey</unittitle>
+          <unitid>14-014</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-19/2014-06-19">June 19, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_9333e53f27cc3c8fa6e94c3b1c3d3dc8" label="Physical Description">13 pages; 1 .wav file, 39 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_3378c7af7e782dadaa6282b6ef0ed864">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_0def83a97198e122ce7f01413f9570bc">
+          <head>Scope Note</head>
+          <p>Jeffrey Hart is a Professor Emeritus of Political Science at Indiana University Bloomington. Hart opens the interview by discussing his initial meeting with Elinor Ostrom, he was interviewing to teach at Indiana University and Elinor Ostrom was about to become the chair of the Department of Political Science. He is also connected to the Vincent Ostrom through a family connection on his wife's side, Joan Hart. He goes onto discuss the way Elinor Ostrom interacted with her graduate students and the influence she had. Hart discusses more of his own research on international political economy and the way that did or did not intertwine with the Ostrom Workshop. This discussion eventually leads to conversation of the future of political science. The interview ends with Hart recalling the Ostrom legacy including the intellectual community the Ostrom Workshop fostered.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_a45cda66825365d97323f43089f43dd6">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_9a30ee2aab71fe1f1a512026024f651e">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">art collections</subject>
+          <subject source="local">intellectual community</subject>
+          <subject source="ingest">political science</subject>
+          <occupation source="local">Professor Emeritus</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <corpname rules="rda" source="local">University of Oregon</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_0cec922c82015cc8c198c132965654ef" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Hart, Joan</unittitle>
+          <unitid>14-012</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-19/2014-06-19">June 19, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_ff976a23eddc1b63344f23bc480d2d53" label="Physical Description">12 pages; 2 .wav files, 49 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_135d3077975806af42725c7e45bb49e6">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_fb743beceb48c61ef85f601e59eb75d0">
+          <head>Scope Note</head>
+          <p>Joan Hart is an art historian and textile specialist. Hart first met Vincent and Elinor Ostrom in Bloomington through political science department parties. Soon after meeting Vincent Ostrom, recognized a connection to Hart through Hart's uncle while they were both at the University of Oregon. Throughout the interview there is discussion of the Ostroms' hobbies such as collecting Native American artifacts like baskets, some of these baskets went on exhibit at the Mathers Museum. Hart goes into detail about the Ostroms' hobby of woodworking, how they were taught, their architectural influence and the pieces the Ostroms' had built which were used throughout the house. This leads to a discussion about the functions of the Ostrom house and the parties they liked to host. Further on Hart describes her time on the schoolboard, how Elinor Ostrom was helpful throughout her campaign. This leads to a discussion about Elinor's recognition for the Nobel Prize and the disparities between men and women in the academic setting. The interview concludes with Hart discussing many examples of Elinor Ostrom's generosity.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_fe287215477e9fd110c689e64ad03a20">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_a8b7a2045892cea762f31f5c94df5945">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="ingest">family history</subject>
+          <subject source="local">Native American art collections</subject>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="ingest">political science</subject>
+          <subject source="ingest">school board</subject>
+          <subject source="ingest">women in academia</subject>
+          <subject source="local">woodworking</subject>
+          <occupation source="local">art historian</occupation>
+          <corpname rules="rda" source="local">Mathers Museum -- Indiana University</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">University of Oregon</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_1ac45d73507cbbc76849e21177cc19f3" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Hess, Charlotte</unittitle>
+          <unitid>14-031</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-07-15/2014-07-15">July 15, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_fa4b0bd7d121d7f2e4b97cdc510ac8f5" label="Physical Description">19 pages; 1 .wav file, 63 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_5b5d0b073f3f91c430fdbc8a85840532">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_6dc09a0d969dfad55458fca0ef4eb948">
+          <head>Scope Note</head>
+          <p>
+Charlotte Hess was the Director of the Library and Information at the Ostrom Workshop from 1989 to 2008. Hess begins by recounting the way the library started and the way it developed, including what it was like to create the library catalog for the Workshop. Hess also talks about connecting the Ostroms' work and the International Association of Common Property. Later, she discusses editing Vincent Ostrom's book
+            <i>The Meaning of Democracy and the Vulnerability of Democracies: A Response to Tocqueville's Challenge</i>
+(1997) and Vincent Ostrom himself.
+          </p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_8dcc07134c4492f1c1f76ae1d7ab0c0d">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_3f885df9309b19804da522f1f772eacd">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">Digital Library of the Commons</subject>
+          <occupation source="local">Director of research</occupation>
+          <occupation source="local">Director of library and information</occupation>
+          <subject source="local">library profession</subject>
+          <subject source="ingest">research</subject>
+          <subject source="local">self-governance</subject>
+          <subject source="local">the commons</subject>
+          <subject source="local"> "The Meaning of Democracy and the Vulnerability of Democracies: A Response to Tocqueville's Challenge" (1997</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <corpname rules="rda" source="local">International Association for Study of the Commons (IASC)</corpname>
+          <corpname rules="rda" source="local">The International Association for the Study of Common Property (IASCP)</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_c3e43e37dbe4656eb89033e32fdf4667" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Kashwan, Prakash</unittitle>
+          <unitid>14-019</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-21/2014-06-21">June 21, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_988629ae1ff510b0735f15dd5dd0b294" label="Physical Description">10 pages; 1 .wav file, 46 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_703e4805020b37230b08e571acfd4131">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_b10a7c01e670dae4fcd2b94a25e9bd4b">
+          <head>Scope Note</head>
+          <p>Prakash Kashwan is an Associate Professor in the Department of Political Science and Co-Director of the Economic and Social Rights Research Group at the Human Rights Institute, at the University of Connecticut, Storrs. Kashwan first met the Ostroms when he came to Indiana University to work on his PhD. He recalls memories with Elinor and Vincent Ostrom. The interview moves on to discuss the Workshop on the Ostrom Workshop (WOW) conference and its future along with the Ostroms intellectual legacy. Kashwan ends by discussing Vincent Ostrom and Elinor Ostrom's teaching.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_3da8f28de58bfd21a9e08c1ab8e75354">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_1eaa00439280edbd6638daee9d2f9037">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="ingest">forestry</subject>
+          <subject source="local">methodological individualism</subject>
+          <subject source="ingest">teaching</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <occupation source="ingest">professor</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_c61832605ba061348d9d2e601fd4f8d9" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Lykens, Kristine</unittitle>
+          <unitid>14-009</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-17/2014-06-17">June 17, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_16483e7c4b9176ae56212cbe00394938" label="Physical Description">20 pages; 1 .wav file, 57 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_7724d9bf600f16434f27912d64727c98">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_d2d2536de29bb20c7d1c3f262a19502f">
+          <head>Scope Note</head>
+          <p>Kristine Lykens is an Associate Professor in the Department of Health Behavior and Health Systems at the University of North Texas. As an undergraduate student at Indiana University she was a student of Elinor and Vincent Ostrom. She discusses her experiences as a student, working with the Ostroms on several projects, and as a teaching intern for the Vincent Ostrom. She also discusses her personal life, her reconnection with Elinor, and her aspirations for her future research that was inspired by her studies under the Ostroms. Kristine Lykens finished her interview discussing the origins of the Ostrom Workshop as well as the Workshop on the Ostrom Workshop (WOW).</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_4cb549624592cf7d9456395cc1cb39f8">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_baa845381afa0012a13cc8b856b31891">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <occupation source="local">associate professor</occupation>
+          <subject source="local">constitutional theory</subject>
+          <subject source="local">health planning agency</subject>
+          <subject source="local">mentorship</subject>
+          <subject source="local">municipalities</subject>
+          <subject source="local">police services</subject>
+          <subject source="local">"Polycentric Circles"</subject>
+          <geogname source="ingest">St. Louis, Missouri</geogname>
+          <occupation source="local">teaching intern</occupation>
+          <geogname source="local">West Africa -- Ghana</geogname>
+          <geogname source="local">West Africa -- Nigeria</geogname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_62a647a860c05714acc56095800bf4c4" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>MacKinnon, Anne</unittitle>
+          <unitid>14-018</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-19/2014-06-19">June 19, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_f3eebaf9cb8697f89d18c77484240860" label="Physical Description">19 pages; 1 .wav file, 63 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_90f566f5ac8a441c24078ea6693e52b4">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_ffcb2089c957eacc0a76dd9a6427a2c3">
+          <head>Scope Note</head>
+          <p>Anne MacKinnon is an Independent Environmental Services Professional. MacKinnon briefly met the Ostroms when she went to a Workshop on the Workshop 3 conference. After this, she applied and became a visiting scholar fall semester of 2005. She discusses her time at the Ostrom Workshop and how she got her Ph.D. MacKinnon explains the Ostrom Workshop community, the Workshop itself and Elinor Ostrom as a teacher.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_bf1b0aac83423c4acc3a9f1ea58cb357">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_e5496d32675014ba2330a18fe03e7734">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <occupation source="local">Environmental Services Professional</occupation>
+          <geogname source="ingest">Berlin, Germany</geogname>
+          <subject source="local">water law</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <occupation source="local">visiting scholar</occupation>
+          <geogname source="ingest">Wyoming</geogname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_3a889f524e60fc5adc7366e14a94ad33" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>McGinnis, Michael</unittitle>
+          <unitid>14-004</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-16/2014-06-16">June 16, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_c8c5ee79aa1bf4b502a0330a2d631257" label="Physical Description">24 pages;1 .wav file, 87 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_4aa86a4473d48ef4d2239ac1d53d1063">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_460738743620fbb72268f8db0521ae2c">
+          <head>Scope Note</head>
+          <p>Michael McGinnis is a Professor Emeritus in the Department of Political Science at Indiana University. McGinnis begins by discussing his interview with the Ostroms for an assistant professor position. He then discusses working with the Ostroms and Political Theory and Policy Analysis within the Ostrom Workshop. McGinnis reflects on his collaboration with Vincent Ostrom while teaching together and Elinor Ostrom through research. The interview closes with McGinnis recounting going to the Nobel Prize ceremony with Elinor Ostrom and working with Elinor Ostrom after the Nobel.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_1c0b60b19e9405ebf8dd8f3871ac0616">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_aa4cf6cb12bafb38085a5f7f0e4603fc">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">political analysis</subject>
+          <subject source="ingest">political science</subject>
+          <subject source="local">political theory</subject>
+          <occupation source="local">Professor Emeritus</occupation>
+          <subject source="local">public administration</subject>
+          <subject source="local">self-governance</subject>
+          <subject source="local">Workshop on the Ostrom Workshop Conference (WOW)</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_1520041be3cfcb96b5d1279ddb0f66cd" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Meinzen-Dick, Ruth</unittitle>
+          <unitid>14-013</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-20/2014-06-20">June 20, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_55baf02fcb3aed50f919b63ea00852ce" label="Physical Description">11 pages; 1 .wav file, 54 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_427973db2b431ae04214dd4da1e34315">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_e049a4370a0d6ad742a486864b147e63">
+          <head>Scope Note</head>
+          <p>In this interview Meinzen-Dick discusses her relationship with Elinor (Lin) Ostrom and how they met, through the International Food Policy Research Institute and the International Association for Study of the Commons (IASC). She goes on to discuss collaboration through the Consultative Group on International Agricultural Research (CIGAR), avoiding hagiography, the IASC conferences, the Ostrom Workshop, and Elinor Ostrom's influence as a role model for women faculty.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_4a8488a9f17832402fa3fa8264bfab43">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_069d6bb5fc8f484e16a0229d87541da8">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <geogname source="ingest">England</geogname>
+          <subject source="local">"Governing the Commons"</subject>
+          <geogname source="ingest">India</geogname>
+          <subject source="local">irrigation</subject>
+          <subject source="local">Institutional Analysis and Development Framework (IAD)</subject>
+          <subject source="local">Nobel Prize</subject>
+          <geogname source="ingest">Philippines</geogname>
+          <occupation source="local">senior research fellow</occupation>
+          <subject source="local">water management</subject>
+          <corpname rules="rda" source="local"> Consultative Group on International Agricultural Research (CGIAR)</corpname>
+          <corpname rules="rda" source="local">International Association for Study of the Commons (IASC)</corpname>
+          <corpname rules="rda" source="local">International Food Policy Research Institute (IFPRI)</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <persname rules="rda" source="local">von Benda-Beckmann, Franz</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_6c6d675eb9e0cd3dd2f83fe4c528f2e1" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Merino, Leticia</unittitle>
+          <unitid>14-021</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-20/2014-06-20">June 20, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_642ea5233b97a118cb1ad0e011dfcff9" label="Physical Description">17 pages; 1 .wav file, 54 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_0211c5093e0156c0cdb4eabd9ffa04db">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_11af82dc10b9b9663bf4d05c40e26dbd">
+          <head>Scope Note</head>
+          <p>Leticia Merino is a researcher with a Doctorate of Anthropology specializing in agrarian studies. Merino opens the interview by discussing her personal background and how her background in forestry led her to Elinor Ostrom's book
+            <i> Governing the Commons </i>. Merino met Ostrom in Mexico through Gustavo Gordillo, a mutual colleague. Merino was asked to go through the International Forestry Resources and Institutions (IFRI) program at the Ostrom Workshop, which she did, and became more involved after taking the course. Merino goes onto discuss collaborating with Ostrom through IFRI and the International Association for the Study of the Commons (IASC). She reflects on her friendship with Ostrom through a discussion of Ostrom's visit to a climate change conference in Mexico. The interview closes with a discussion on the 2012 Planet Under Pressure Conference in London where Ostrom was a keynote speaker.
+          </p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_ea4b7247046ef96c6a8ac1c5b8ce683d">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_b8b7f4f3f1bdf4de2d68fed25e9a72f1">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">conferences</subject>
+          <subject source="ingest">forestry</subject>
+          <subject source="local">"Governing the Commons"</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">International Association for Study of the Commons (IASC)</corpname>
+          <corpname rules="rda" source="local">International Forestry Resources and Institutions (IFRI)</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_1ef680f43094dc14f61c7679f375a3aa" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Nagendra, Harini</unittitle>
+          <unitid>14-026</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-07-02/2014-07-02">July 02, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_a2801810ce2c0865ec3d51c5e7c1fea4" label="Physical Description">18 pages; 2 .wav files, 66 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_d0cfca244a11d3731f551ce29eae1583">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_7a95c5672fd94e3e675c466fe4c85c59">
+          <head>Scope Note</head>
+          <p>Harini Nagendra is a professor of sustainability and coordinator of the Centre for Urban Sustainability at Azim Premji University in Bangalore India. Nagendra describes her personal background that lead her to contact Elinor Ostrom while pursing postdoctoral opportunities. She received a research position at the Center for the Study of Institutions, Populations and Environmental Change (CIPEC) focusing on human-nature interactions in Asia. Furthermore, she discusses her research in collaboration with Ostrom on Bangalore urban villages and their connections to lakes such as Lake Kaikondrahhalli. Later on Nagendra discusses Elinor Ostrom's Nobel Prize and her impact on future research. There is also discussion of Elinor Ostrom and Vincent Ostrom and Nagendra's connect with them. She goes onto describe their personalities and generosity, last memories, and the Ostroms' as collectors.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_3f1b46fa1c6e7fa58946d73f67bdd1d6">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_449e99e577f63d1d2ed9d23b091eda8f">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <geogname source="ingest">Bangalore, India</geogname>
+          <subject source="ingest">ecology</subject>
+          <subject source="ingest">biodiversity</subject>
+          <geogname source="local">Lake Kaikondrahalli, India</geogname>
+          <geogname source="ingest">Nepal</geogname>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">Social-Ecological Systems Framework</subject>
+          <corpname rules="rda" source="local">Center of Excellence of the Study of Population, Institutions, and Environmental Change (CIPEC)</corpname>
+          <corpname rules="rda" source="local">Foundation for Ecological Security</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_552e726d59297c800c67803dc572e45b" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Parks, Carol</unittitle>
+          <unitid>14-005</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Colom, Gloria</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-11/2014-06-11">June 11, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_b32a4ced84978120c17a12e925fdb543" label="Physical Description">14 pages; 1 .wav file, 126 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_a5290e78ab7b2266f11acf65b7226c15">
+          <head>Access Status</head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_ed0249f12c10faae7c3a9fe5d0be7484">
+          <head>Scope Note</head>
+          <p>Carol Parks is the spouse of Roger Parks and friend of the Ostroms'. Roger Parks is a former student of Elinor Ostrom's, which is how they initially met. Carol Parks built a stronger relationship with Elinor Ostrom while cataloging the artwork in the Ostrom house. During this cataloging project Elinor Ostrom and Parks consulted many different people and agencies including the Mathers Museum. This leads to a discussion about the construction of the Ostrom house, which was built like a Native American longhouse. She further discusses the Ostroms' collection of Native American work while they were at their Manitoulin Island house in Ontario, Canada. Roger and Carol Parks had the opportunity to go to this house on the island which is discussed. Parks then discusses the impact of Elinor Ostrom's Nobel Prize in Economics and the changes in the Ostrom Workshop over the years. The interview concludes with personal antecedents about the Ostroms.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_6729cdc1590c5fcafb488db473aa3449">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_1370f28fa857d81a361208d45b55c650">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="ingest">architecture</subject>
+          <subject source="local">art collections</subject>
+          <subject source="ingest">Native Americans</subject>
+          <subject source="local">Nobel Prize</subject>
+          <geogname source="local">Manitoulin Island, Ontario, Canada</geogname>
+          <corpname rules="rda" source="local">Mathers Museum -- Indiana University</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_f8e3d8694cf16da494b7ce34069bafd2" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Parks, Roger</unittitle>
+          <unitid>14-001</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-04/2014-06-04">June 04. 2014</unitdate>
+          <physdesc audience="internal" id="aspace_5e773a50e29de0b9bed9543db28a0f8d" label="Physical Description">21 pages; 1 .wav file, 76 mintues; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_3c3151d60cfad4e23df1bcaf7b7442f3">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_52a0c724327ce31835d07fba48eae7d1">
+          <head>Scope Note</head>
+          <p>Roger Parks is an Professor Emeritus of Public and Environmental Affairs at Indiana University. He was a student, co-worker, and friend of Elinor (Lin) Ostrom and Vincent Ostrom. In this interview Parks discusses his relationship with the Ostroms', projects he worked on and his role at the Ostrom Workshop where he was a graduate student worker and later became the Associate Director.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_279a6dc3b531b4a82d40eee5e2727b16">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_c8a0277fc0fbccc017aad216d582526f">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <geogname source="ingest">Indianapolis, Indiana</geogname>
+          <subject source="local">Measure Project</subject>
+          <subject source="local">Nobel Prize</subject>
+          <occupation source="local">Professor Emeritus</occupation>
+          <subject source="local">police studies</subject>
+          <subject source="ingest">research</subject>
+          <geogname source="ingest">St. Louis, Missouri</geogname>
+          <corpname source="ingest">American Political Science Association</corpname>
+          <persname rules="rda" source="local">Guarasci, Richard</persname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">National Institute of Justice</corpname>
+          <corpname authfilenumber="n79005681" rules="rda" source="lcnaf">National Science Foundation (U.S.)</corpname>
+          <corpname source="ingest">National Institute of Mental Health</corpname>
+          <persname rules="rda" source="local">Smith, Dennis</persname>
+          <corpname rules="rda" source="local">University of North Carolina</corpname>
+          <persname rules="rda" source="local">Whitaker, Gordon</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_7596b195ea733cb29967fb949e976994" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Pradhan, Prachanda</unittitle>
+          <unitid>14-025</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-25/2014-06-25">June 25, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_3d3322f0cdec9b2bc2d5e60ccb88314a" label="Physical Description">10 pages; 1 .wav file, 44 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_36e22b69db12d5b03fbe7f98e5064428">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_045b45d8f945fc5cf5577a61df1ef54a">
+          <head>Scope Note</head>
+          <p>Dr. Prachanda Pradhan is a leading scholar who has been promoting values and benefits of farmer managed irrigation system in Nepal and other developing countries. Pradhan begins the interview by discussing how he met Elinor Ostrom, her visit to Nepal and their roles in the Farmer Managed Irrigation Systems Promotion Trust. He further discusses his working relationship and personal relationship with Elinor Ostrom while collaboratively writing Improving Irrigation in Asia. Also mentioned is how Pradhan learned from Elinor Ostrom and Vincent Ostrom through the Ostrom Workshop and other methods.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_59bc55384b116b9698f158f41b5f618a">
+          <head>Conditions Governing Use</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_0a05abb73305e0ffdbc4a843e8d4e257">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">farmer-managed irrigation systems</subject>
+          <subject source="local">"Improving Irrigation in Asia"</subject>
+          <geogname source="ingest">Nepal</geogname>
+          <occupation source="local">scholar</occupation>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_6d1db689a47f58b94715431af2042789" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Swindell, David</unittitle>
+          <unitid>14-017</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Stahlman, Joseph</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2014-06-21/2014-06-21">June 21, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_1018289a4fa9be3f88d698639860aad4" label="Physical Description">21 pages; 1 .wav file, 74 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_745707b38153a8677c1b11f537b4baed">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_877f58161c03f054f0b5a0cbc5f4deba">
+          <head>Scope Note</head>
+          <p>David Swindell is the Director of the Center for Urban Innovation at Arizona State University. The interview begins with Swindell recounting how he got to know Elinor and Vincent Ostrom and his graduate research at the Ostrom Workshop. Discussion of research at the Ostrom Workshop leads to a discussion of the application of polycentricity of applied research. Swindell closes with his personal memories of Elinor and Vincent Ostrom and their legacy.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_6bbac495d8452a82ee8b1d657c064668">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_0f99be4758c02ffd3396bccfcd8aee60">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">American Political Science Review</subject>
+          <occupation source="local">Director</occupation>
+          <geogname source="ingest">Indianapolis, Indiana</geogname>
+          <subject source="local">municipal federalism</subject>
+          <geogname source="ingest">Phoenix, Arizona</geogname>
+          <subject source="local">Polycentricity</subject>
+          <corpname rules="rda" source="local">Arizona State University Center for Urban Innovation</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <persname rules="rda" source="local">Parks, Roger</persname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_055daec7327829cc600e23ece8826551" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Tucker, Catherine</unittitle>
+          <unitid>14-027</unitid>
+          <origination label="Creator">
+            <persname role="ivr" rules="rda" source="local">Guerrero, Paulina</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce">July 09, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_ebb486ddb752625958c66451cd0a6410" label="Physical Description">18 pages; 2 .wav files, 62 minutes; no index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+            .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_adaaad3160a79316c432fa9ff02953cc">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_e69a1686dc28473b6933c6d787ea8ddc">
+          <head>Scope Note</head>
+          <p>Catherine Tucker has a joint appointment with the Department of Anthropology and the Center for Latin American Studies at the University of Florida. Tucker begins her interview by recounting how she met Elinor Ostrom and her experiences with her at the Center for the Study of Institutions, Population, and Environmental Change (CIPEC). She goes on to discuss Ostrom as a mentor and her own teaching. Tucker then talks about her work at the Ostrom Workshop which includes her teaching with the International Forestry Research and Institutions Research Program (IFRI). The interview concludes with Tucker reflecting on Elinor Ostrom and Vincent Ostrom and how they, especially Elinor Ostrom, would want to be remembered.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_a7370bf422ff595038f0c10204ab47bd">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_107240cd38155956ab62dc8c21847068">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">cooperation</subject>
+          <subject source="local">forest management</subject>
+          <geogname source="ingest">Mexico</geogname>
+          <occupation source="ingest">professor</occupation>
+          <corpname rules="rda" source="local">Center of Excellence of the Study of Population, Institutions, and Environmental Change (CIPEC)</corpname>
+          <corpname rules="rda" source="local">International Forestry Resources and Institutions (IFRI)</corpname>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <persname audience="internal">Ostrom, Vincent, 1919-2012</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+        </controlaccess>
+      </c01>
+      <c01 audience="internal" id="aspace_6a1c5202d0a2337273cf362fd04bf0ae" level="otherlevel" otherlevel="Interview">
+        <did>
+          <unittitle>Walker, James</unittitle>
+          <unitid>14-006</unitid>
+          <origination label="Creator">
+            <persname rules="rda" source="local">Clark, Sara</persname>
+          </origination>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="214-06-11/214-06-11">June 11, 2014</unitdate>
+          <physdesc audience="internal" id="aspace_c603874922a8934e4d2cc2d453fc8fc7" label="Physical Description">26 pages; 1 .wav file, 88 minutes; index</physdesc>
+          <langmaterial>
+            <language langcode="eng" scriptcode="Latn">English</language>
+          .
+          </langmaterial>
+        </did>
+        <accessrestrict audience="internal" id="aspace_f640a4d86acf46e0d1eb4df17c894764">
+          <head>Access Status </head>
+          <p>Open</p>
+        </accessrestrict>
+        <scopecontent audience="internal" id="aspace_9d00f759e7bbb2f028846a0b3b221f2b">
+          <head>Scope Note</head>
+          <p>James Walker is a Professor of Economics at Indiana University. Walker first worked with Elinor Ostrom on a National Science Foundation proposal with Roy Gardner which is discussed in detail. After years of collaboration with the Ostroms, Walker became closer to them which led to him going with Elinor Ostrom to the Nobel Prize ceremony and he became executor of their estate. Walker also discusses the history of the Ostrom Workshop and the way it evolved over the years.</p>
+        </scopecontent>
+        <userestrict audience="internal" id="aspace_da3f0bf524dc9c8c02224eb12e618906">
+          <head>Usage Restrictions</head>
+          <p>The archive of the Center for Documentary Research and Practice at Indiana University is open to the use of researchers. Copies of transcript pages are available only when such copies are permitted by the deed of gift. Scholars must honor any restrictions the interviewee placed on the use of the interview. Since some of our earlier (pre-computer) transcripts do not exist in final form, any editing marks in a transcript (deletions, additions, corrections) are to be quoted as marked. Audio files may not be copied for patrons unless the deed of gift permits it, and a transcript is unavailable for that interview. The same rules of use that apply to a transcript apply to the audio interview. Interviews may not be reproduced in full for any public use, but excerpted quotes may be used as long as researchers fully cite the data in their research, including accession number, interview date, interviewee's and interviewer's name, and page(s).</p>
+        </userestrict>
+        <prefercite audience="internal" id="aspace_d7820743ebd84378bc584ea20cd8e86b">
+          <head>Preferred Citation</head>
+          <p>[interviewee first name last name] interview, by [interviewer first name last name], [interview date(s)], [call number], [project name], Center for Documentary Research and Practice, Indiana University, Bloomington, [page number(s) or tape number and side if no transcript; if digital audio and no transcript, cite time when quote occurs].</p>
+        </prefercite>
+        <controlaccess>
+          <subject source="local">executor</subject>
+          <subject source="local">experiments</subject>
+          <subject source="local">experimental economics</subject>
+          <subject source="local">game theory</subject>
+          <subject source="local">Nobel Prize</subject>
+          <subject source="local">political theory</subject>
+          <subject source="local">policy analysis</subject>
+          <persname audience="internal" rules="rda" source="lcnaf">Ostrom, Elinor</persname>
+          <corpname rules="rda" source="local">Ostrom Workshop</corpname>
+          <persname rules="rda" source="local">Gardner, Roy</persname>
+        </controlaccess>
+      </c01>
+    </dsc>
+  </archdesc>
+</ead>

--- a/lib/arclight/creator_roles.rb
+++ b/lib/arclight/creator_roles.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative 'relator_service'
+
+##
+# A utility class to normalize creators by joining
+# the role and creator name into a hash object containing the
+# unique roles as keys and an array of one or more creator names
+module Arclight
+  class CreatorRoles
+    # @param [Array > Hash] [{creator: 'creator name', role: 'role name'}]
+    def initialize(creator_roles:, logger: nil)
+      @creator_roles = creator_roles
+      @result = []
+      @logger = logger
+    end
+
+    # @return [String] the normalized creator/role hash string
+    def to_s
+      normalize
+    end
+
+    private
+
+    attr_reader :creator_roles, :result, :logger
+
+    def normalize
+      @logger&.debug("👻👻 Formatting creator roles: #{@creator_roles}") if logger
+      @creator_roles.each do |creator_role|
+        creator = creator_role[:creator]
+        role = creator_role[:role] || 'creator'
+        combine_roles(creator, role)
+      end
+      results = translate_roles(@result)
+      @logger&.debug("✅✅ Creator roles: #{results}") if logger
+      @logger&.debug("🚫🚫🚫🚫🚫🚫🚫🚫🚫🚫🚫") if logger
+      results
+    end
+
+    def combine_roles(creator, role)
+      # Check if the role already exists as a key in any hash within @result
+      existing_entry = @result.find { |hash| hash.key?(role) }
+      if existing_entry
+        # If the role exists, add the creator to the array of creators for that role
+        existing_entry[role] << creator
+      else
+        # If the role doesn't exist, create a new hash with the role as the key
+        @result << { role => [creator] }
+      end
+    end
+
+    def translate_roles(results)
+      result_array = []
+
+      results.each do |role_hash|
+        key = role_hash.keys.first
+        translated_role = RelatorService.for(key) || key.titleize
+        role_hash[translated_role] = role_hash.delete(key)
+        result_array << role_hash.to_json
+      end.to_json
+      result_array
+    end
+  end
+end

--- a/lib/arclight/relator_service.rb
+++ b/lib/arclight/relator_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rdf'
+require 'rdf/ntriples'
+
+module Arclight
+  class RelatorService
+    attr_reader :graph
+
+    def self.for(code)
+      return nil if code.blank?
+      @instance ||= new
+      @instance.get_authoritative_label(code)
+    end
+
+    def initialize(file_path: default_file_path)
+      @graph = RDF::Graph.load(file_path, format: :ntriples)
+    end
+
+    # Method to get the authoritativeLabel for a given code
+    def get_authoritative_label(code)
+      subject = RDF::URI("http://id.loc.gov/vocabulary/relators/#{code}")
+      predicate = RDF::URI("http://www.loc.gov/mads/rdf/v1#authoritativeLabel")
+
+      # Return the authoritativeLabel for the subject
+      label = @graph.query([subject, predicate, nil]).first&.object
+      return nil unless label
+      label.to_s
+    end
+
+
+    private
+
+    def default_file_path
+      if defined?(Rails)
+        Rails.root.join('config', 'relators.nt').to_s
+      else
+        File.expand_path('../../config/relators.nt', __dir__)
+      end
+    end
+  end
+end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -9,6 +9,8 @@ require 'arclight/level_label'
 require 'arclight/normalized_id'
 require 'arclight/normalized_date'
 require 'arclight/normalized_title'
+# IU customization: index creator roles with names
+require_relative '../creator_roles'
 require 'active_model/conversion' ## Needed for Arclight::Repository
 require 'active_support/core_ext/array/wrap'
 require 'arclight/digital_object'
@@ -23,6 +25,8 @@ extend TrajectPlus::Macros
 # rubocop:enable Style/MixinUsage
 
 NAME_ELEMENTS = %w[corpname famname name persname].freeze
+
+CREATOR_ELEMENTS = %w[corpname famname persname].freeze
 
 SEARCHABLE_NOTES_FIELDS = %w[
   accessrestrict
@@ -59,6 +63,7 @@ settings do
   provide 'id_normalizer', 'Arclight::NormalizedId'
   provide 'date_normalizer', 'Arclight::NormalizedDate'
   provide 'title_normalizer', 'Arclight::NormalizedTitle'
+  provide 'creator_roles_normalizer', 'Arclight::CreatorRoles'
   provide 'reader_class_name', 'Arclight::Traject::NokogiriNamespacelessReader'
   provide 'solr_writer.commit_on_close', 'true'
   provide 'repository', ENV.fetch('REPOSITORY_ID', nil)
@@ -159,6 +164,17 @@ to_field 'creator_ssm', extract_xpath('/ead/archdesc/did/origination')
 to_field 'creator_ssim', extract_xpath('/ead/archdesc/did/origination')
 to_field 'creator_sort' do |record, accumulator|
   accumulator << record.xpath('/ead/archdesc/did/origination').map { |c| c.text.strip }.join(', ')
+end
+
+to_field 'creator_role_ssim' do |record, accumulator|
+  roles_array = []
+  CREATOR_ELEMENTS.map do |selector|
+    creator = record.at_xpath("/ead/archdesc/did/origination/#{selector}")
+    next unless creator
+    role = creator&.attribute('role')&.value
+    roles_array << { creator: creator&.text.strip, role: role }
+  end
+  accumulator << settings['creator_roles_normalizer'].constantize.new(creator_roles: roles_array, logger: settings['logger']).to_s if roles_array.present?
 end
 
 to_field 'creator_persname_ssim', extract_xpath('/ead/archdesc/did/origination/persname')


### PR DESCRIPTION
## Details
refs https://github.com/notch8/archives_online/issues/149

- Adds relators file and lookup service to translate relators from roles.
- Adds new term to index creators with their roles.
- Supports rendering of the roles as labels in the show view, by using a custom component to parse the indexed term's label as long as there is only one, and a helper to render the values.
- Mainatains the existing functionality of displaying the creator's name as a URL.